### PR TITLE
Updated capstone-sys dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.0.6"
 
 [dependencies]
 libc = "0.2"
-capstone-sys = "0.3.0"
+capstone-sys = "0.4.0"
 
 # Not actually a dependency, but this makes the more complicated examples work
 [dev-dependencies]


### PR DESCRIPTION
```
    Updating git repository `https://github.com/capstone-rust/capstone-rs`
    Updating registry `https://github.com/rust-lang/crates.io-index`
error: no matching package named `capstone-sys` found (required by `capstone`)
location searched: registry https://github.com/rust-lang/crates.io-index
version required: ^0.3.0
versions found: 0.4.0, 0.2.0, 0.1.0
```