### PR TITLE
API refactor WIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Capstone::new_raw()` has the same interface as the old `Capstone::new_raw()`
+- Add setters to modify mode, syntax, etc.
+
+### Changed
+- `Capstone::new()` uses the builder pattern
+- Partition `Mode` enum into: `Mode`, `ExtraMode`, and `Endian`
 
 ## [0.1.0] - 2017-09-29
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ To produce a short demonstration. More complex demos welcome!
 - Binding Author(s):
     - m4b <m4b.github.io@gmail.com>
     - Richo Healey <richo@psych0tik.net>
+    - Travis Finkenauer <tmfinken@gmail.com>
 
 You may find a [full list of contributors on Github](https://github.com/capstone-rust/capstone-rs/graphs/contributors).
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,11 +1,17 @@
 extern crate capstone;
 
+use capstone::prelude::*;
+
 const CODE: &'static [u8] = b"\x55\x48\x8b\x05\xb8\x13\x00\x00";
 
-fn example() -> capstone::CsResult<()> {
-    let mut cs = capstone::Capstone::new(capstone::Arch::X86, capstone::Mode::Mode64)?;
-    cs.set_detail(true).unwrap();
-    cs.att();
+fn example() -> CsResult<()> {
+    let cs = Capstone::new()
+        .x86()
+        .mode(arch::x86::ArchMode::Mode64)
+        .syntax(arch::x86::ArchSyntax::Att)
+        .detail(true)
+        .build()?;
+
     let insns = cs.disasm_all(CODE, 0x1000)?;
     println!("Got {} instructions", insns.len());
     for i in insns.iter() {

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -1,0 +1,312 @@
+//! Contains architecture-specific types and modules
+
+use capstone::Capstone;
+use constants::Endian;
+use error::CsResult;
+use std::marker::PhantomData;
+
+macro_rules! define_subset_enum {
+    ( [
+        $subset_enum:ident = $base_enum:ident
+      ]
+      $( $variant:ident, )*
+    ) => {
+        #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+        pub enum $subset_enum {
+            $(
+                $variant,
+            )*
+        }
+
+        impl From<$subset_enum> for $base_enum {
+            fn from(other: $subset_enum) -> $base_enum {
+                match other {
+                    $(
+                        $subset_enum::$variant => $base_enum::$variant,
+                    )*
+                }
+            }
+        }
+    };
+}
+
+macro_rules! define_arch_builder {
+    // ExtraMode rules
+    ( @extra_modes () ) => {};
+    ( @extra_modes ( $( $extra_mode:ident, )+ ) ) => {
+        impl super::BuildsCapstoneExtraMode<ArchMode, ArchExtraMode> for ArchCapstoneBuilder {
+            fn extra_mode<T: Iterator<Item=ArchExtraMode>>(&mut self, extra_mode: T) -> & mut Self {
+                // self.extra_mode = extra_mode.fold(0usize, |acc, x|
+                //     acc | cs_mode::from(x) as usize);
+                self.extra_mode.clear();
+                self.extra_mode.extend(extra_mode);
+                self
+            }
+        }
+    };
+
+    // Syntax rules
+    ( @syntax () ) => {};
+    ( @syntax ( $( $syntax:ident, )+ ) ) => {
+        impl super::BuildsCapstoneSyntax<ArchMode, ArchSyntax> for ArchCapstoneBuilder {
+            fn syntax(& mut self, syntax: ArchSyntax) -> &mut Self {
+                self.syntax = Some(syntax);
+                self
+            }
+        }
+    };
+
+    // Endian rules
+    ( @endian ( false) ) => {};
+    ( @endian ( true ) ) => {
+        impl super::BuildsCapstoneEndian<ArchMode> for ArchCapstoneBuilder {
+            fn endian(&mut self, endian: Endian) -> &mut Self {
+                self.endian = Some(endian);
+                self
+            }
+        }
+    };
+
+    // Entrance rule
+    (
+        $( [
+            ( $arch:ident, $arch_variant:ident )
+            ( mode: $( $mode:ident, )+ )
+            ( extra_modes: $( $extra_mode:ident, )* )
+            ( syntax: $( $syntax:ident, )* )
+            ( both_endian: $( $endian:ident )* )
+        ] )+
+    ) => {
+        $(
+            pub mod $arch {
+                use capstone::Capstone;
+                use constants::{Arch, Endian, ExtraMode, Mode, Syntax};
+                use error::{CsResult, Error};
+
+                define_arch_builder!( @syntax ( $( $syntax, )* ) );
+                define_arch_builder!( @endian ( $( $endian )* ) );
+                define_arch_builder!( @extra_modes ( $( $extra_mode, )* ) );
+
+                define_subset_enum!(
+                    [ ArchMode = Mode ]
+                    $( $mode, )*
+                );
+
+                define_subset_enum!(
+                    [ ArchExtraMode = ExtraMode ]
+                    $( $extra_mode, )*
+                );
+
+                define_subset_enum!(
+                    [ ArchSyntax = Syntax ]
+                    $( $syntax, )*
+                );
+
+                pub struct ArchCapstoneBuilder {
+                    pub(crate) mode: Option<ArchMode>,
+                    pub(crate) is_detail: bool,
+                    pub(crate) extra_mode: Vec<ArchExtraMode>,
+                    pub(crate) syntax: Option<ArchSyntax>,
+                    pub(crate) endian: Option<Endian>,
+                }
+
+                impl super::BuildsCapstone<ArchMode> for ArchCapstoneBuilder {
+                    fn mode(&mut self, mode: ArchMode) -> &mut Self {
+                        self.mode = Some(mode);
+                        self
+                    }
+
+                    fn detail(&mut self, enable_detail: bool) -> &mut Self {
+                        self.is_detail = enable_detail;
+                        self
+                    }
+
+                    fn build(&mut self) -> CsResult<Capstone> {
+                        let mode = match self.mode {
+                            Some(mode) => mode,
+                            None => {
+                                let msg: &'static str = concat!(
+                                    "Must specify mode for ",
+                                    stringify!($arch),
+                                    "::ArchCapstoneBuilder with `mode()` method",
+                                );
+                                return Err(Error::CustomError(msg));
+                            }
+                        };
+                        let extra_mode = self.extra_mode.iter().map(|x| ExtraMode::from(*x));
+                        let mut capstone = Capstone::new_raw(Arch::$arch_variant,
+                                                             mode.into(),
+                                                             extra_mode,
+                                                             self.endian)?;
+
+                        if let Some(syntax) = self.syntax {
+                            capstone.set_syntax(Syntax::from(syntax))?;
+                        }
+                        if self.is_detail {
+                            capstone.set_detail(self.is_detail)?;
+                        }
+
+                        Ok(capstone)
+                    }
+                }
+
+                impl Default for ArchCapstoneBuilder {
+                    fn default() -> Self {
+                        ArchCapstoneBuilder {
+                            mode: None,
+                            is_detail: false,
+                            extra_mode: vec![],
+                            endian: None,
+                            syntax: None,
+                        }
+                    }
+                }
+            }
+        )+
+
+
+        impl CapstoneBuilder {
+            pub(crate) fn new() -> Self {
+                CapstoneBuilder(PhantomData)
+            }
+
+            $(
+                pub fn $arch(self) -> $arch::ArchCapstoneBuilder {
+                    Default::default()
+                }
+            )*
+        }
+    }
+}
+
+/// Builds a `Capstone` struct
+pub trait BuildsCapstone<ArchMode> {
+    /// Set the disassembly mode
+    fn mode(&mut self, mode: ArchMode) -> &mut Self;
+
+    /// Enable detailed output
+    fn detail(&mut self, enable_detail: bool) -> &mut Self;
+
+    /// Get final `Capstone`
+    fn build(&mut self) -> CsResult<Capstone>;
+}
+
+/// Implies that a `CapstoneBuilder` architecture has extra modes
+pub trait BuildsCapstoneExtraMode<ArchMode, ArchExtraMode>
+    : BuildsCapstone<ArchMode> {
+    /// Set architecture endianness
+    fn extra_mode<T: Iterator<Item = ArchExtraMode>>(&mut self, extra_mode: T) -> &mut Self;
+}
+
+/// Implies that a `CapstoneBuilder` has different syntax options
+pub trait BuildsCapstoneSyntax<ArchMode, ArchSyntax>: BuildsCapstone<ArchMode> {
+    /// Set the disassembly syntax
+    fn syntax(&mut self, syntax: ArchSyntax) -> &mut Self;
+}
+
+/// Implies that a `CapstoneBuilder` architecture has a configurable endianness
+pub trait BuildsCapstoneEndian<ArchMode>: BuildsCapstone<ArchMode> {
+    /// Set architecture endianness
+    fn endian(&mut self, endian: Endian) -> &mut Self;
+}
+
+define_arch_builder!(
+    [
+        ( arm, ARM )
+        ( mode:
+            Arm,
+            Thumb,
+            )
+        ( extra_modes:
+            MClass,
+            V8,
+            )
+        ( syntax:
+            NoRegName,
+            )
+        ( both_endian: true )
+    ]
+    [
+        ( arm64, ARM64 )
+        ( mode:
+            Arm,
+            )
+        ( extra_modes: )
+        ( syntax: )
+        ( both_endian: true )
+    ]
+    [
+        ( mips, MIPS )
+        ( mode:
+            Mode32,
+            Mode64,
+            Mips32R6,
+            MipsGP64,
+            )
+        ( extra_modes:
+            Micro,
+            )
+        ( syntax: )
+        ( both_endian: true )
+    ]
+    [
+        ( ppc, PPC )
+        ( mode:
+            Mode32,
+            Mode64,
+            )
+        ( extra_modes: )
+        ( syntax:
+            NoRegName,
+            )
+        ( both_endian: true )
+    ]
+    [
+        ( sparc, SPARC )
+        ( mode:
+            Default,
+            V9,
+            )
+        ( extra_modes: )
+        ( syntax: )
+        ( both_endian: false )
+    ]
+    [
+        ( sysz, SYSZ )
+        ( mode:
+            Default,
+            )
+        ( extra_modes: )
+        ( syntax: )
+        ( both_endian: false )
+    ]
+    [
+        ( x86, X86 )
+        ( mode:
+            Mode16,
+            Mode32,
+            Mode64,
+            )
+        ( extra_modes: )
+        ( syntax:
+            Intel,
+            Att,
+            )
+        ( both_endian: false )
+    ]
+    [
+        ( xcore, XCORE )
+        ( mode:
+            Default,
+            )
+        ( extra_modes: )
+        ( syntax: )
+        ( both_endian: false  )
+    ]
+);
+
+/// Builds `Capstone` object
+pub struct CapstoneBuilder(
+    /// Hidden field to prevent users from instantiating `CapstoneBuilder`
+    PhantomData<()>
+);

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,7 @@
 use capstone_sys::*;
 use capstone_sys::cs_arch::*;
 use capstone_sys::cs_mode::*;
+use capstone_sys::cs_opt_value::*;
 use std::convert::From;
 
 /// Define an `enum` that corresponds to a capstone enum
@@ -9,10 +10,7 @@ use std::convert::From;
 macro_rules! define_cs_enum_wrapper {
     ( [
         $( #[$enum_attr:meta] )*
-        => $rust_enum:ident = $cs_enum:ident,
-        $( #[$cs_to_rust_attrs:meta] )*
-        ,
-        $( #[$rust_to_cs_attrs:meta] )*
+        => $rust_enum:ident = $cs_enum:ident
       ]
       $( $( #[$attr:meta] )*
       => $rust_variant:ident = $cs_variant:tt; )* ) => {
@@ -26,19 +24,7 @@ macro_rules! define_cs_enum_wrapper {
             )*
         }
 
-        $( #[$cs_to_rust_attrs] )*
-        impl From<$cs_enum> for $rust_enum {
-            fn from(other: $cs_enum) -> Self {
-                match other {
-                    $(
-                        $cs_enum::$cs_variant => $rust_enum::$rust_variant,
-                    )*
-                }
-            }
-        }
-
-        $( #[$rust_to_cs_attrs] )*
-        impl From<$rust_enum> for $cs_enum {
+        impl ::std::convert::From<$rust_enum> for $cs_enum {
             fn from(other: $rust_enum) -> Self {
                 match other {
                     $(
@@ -53,8 +39,7 @@ macro_rules! define_cs_enum_wrapper {
 define_cs_enum_wrapper!(
     [
         /// Architectures for the disassembler
-        => Arch = cs_arch,
-        ,
+        => Arch = cs_arch
     ]
     /// ARM (Advanced RISC Machine)
     => ARM = CS_ARCH_ARM;
@@ -72,22 +57,15 @@ define_cs_enum_wrapper!(
     => SYSZ = CS_ARCH_SYSZ;
     /// XCore
     => XCORE = CS_ARCH_XCORE;
-    => MAX = CS_ARCH_MAX;
-    /// used for `cs_support()`
-    => ALL = CS_ARCH_ALL;
 );
 
 define_cs_enum_wrapper!(
     [
         /// Disassembler modes
-        => Mode = cs_mode,
-        #[cfg(other)]
-        ,
+        => Mode = cs_mode
     ]
-    /// little-endian mode
-    => LittleEndian = CS_MODE_LITTLE_ENDIAN;
     /// 32-bit ARM
-    => Arm32 = CS_MODE_ARM;
+    => Arm = CS_MODE_ARM;
     /// 16-bit mode (X86)
     => Mode16 = CS_MODE_16;
     /// 32-bit mode (X86)
@@ -96,12 +74,6 @@ define_cs_enum_wrapper!(
     => Mode64 = CS_MODE_64;
     /// ARM's Thumb mode, including Thumb-2
     => Thumb = CS_MODE_THUMB;
-    /// ARM's Cortex-M series
-    => MClass = CS_MODE_MCLASS;
-    /// ARMv8 A32 encodings for ARM
-    => V8 = CS_MODE_V8;
-    /// MicroMips mode (MIPS)
-    => Micro = CS_MODE_MICRO;
     /// Mips III ISA
     => Mips3 = CS_MODE_MIPS3;
     /// Mips32r6 ISA
@@ -110,12 +82,45 @@ define_cs_enum_wrapper!(
     => MipsGP64 = CS_MODE_MIPSGP64;
     /// SparcV9 mode (Sparc)
     => V9 = CS_MODE_V9;
-    /// big-endian mode
-    => BigEndian = CS_MODE_BIG_ENDIAN;
-    /// Mips32 ISA (Mips)
-    => Mips32 = CS_MODE_MIPS32;
-    /// Mips64 ISA (Mips)
-    => Mips64 = CS_MODE_MIPS64;
+    /// Default mode for little-endian
+    => Default = CS_MODE_LITTLE_ENDIAN;
+);
+
+define_cs_enum_wrapper!(
+    [
+        /// Extra modes or features that can be enabled with some modes
+        => ExtraMode = cs_mode
+    ]
+    /// ARM's Cortex-M series. Works with `Arm` mode.
+    => MClass = CS_MODE_MCLASS;
+    /// ARMv8 A32 encodings for ARM. Works with `Arm` and `Thumb` modes.
+    => V8 = CS_MODE_V8;
+    /// MicroMips mode. Works in `MIPS` mode.
+    => Micro = CS_MODE_MICRO;
+);
+
+define_cs_enum_wrapper!(
+    [
+        /// Disassembler endianness
+        => Endian = cs_mode
+    ]
+    /// Little-endian mode
+    => Little = CS_MODE_LITTLE_ENDIAN;
+    /// Big-endian mode
+    => Big = CS_MODE_BIG_ENDIAN;
+);
+
+define_cs_enum_wrapper!(
+    [
+        /// Disassembly syntax
+        => Syntax = cs_opt_value
+    ]
+    /// Intel syntax
+    => Intel = CS_OPT_SYNTAX_INTEL;
+    /// AT&T syntax (also known as GNU assembler/GAS syntax)
+    => Att = CS_OPT_SYNTAX_ATT;
+    /// No register name
+    => NoRegName = CS_OPT_SYNTAX_NOREGNAME;
 );
 
 pub(crate) struct OptValue(pub cs_opt_value);
@@ -127,5 +132,21 @@ impl From<bool> for OptValue {
         } else {
             OptValue(cs_opt_value::CS_OPT_OFF)
         }
+    }
+}
+
+/// Representation of `cs_mode`. We use this to have a type that we can transmute() to that has
+/// the same memory representation.
+pub(crate) type CsModeRepr = i32;
+
+#[cfg(test)]
+mod test {
+    use capstone_sys::cs_mode;
+    use std::mem;
+    use super::CsModeRepr;
+
+    #[test]
+    fn test_cs_mode_size() {
+        assert_eq!(mem::size_of::<cs_mode>(), mem::size_of::<CsModeRepr>());
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ use std::result;
 /// Create `RustFeatures` struct definition, `new()`, and a getter for each field
 macro_rules! capstone_error_def {
     ( $( $( #[$attr:meta] )* => $rust_variant:ident = $cs_variant:ident; )* ) => {
+        /// Error for Capstone
         #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
         pub enum CapstoneError {
             $(

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -3,7 +3,7 @@ extern crate libc;
 use std::ffi::CStr;
 use std::ptr;
 use std::str;
-use std::fmt::{self, Display, Debug, Formatter, Error};
+use std::fmt::{self, Debug, Display, Error, Formatter};
 use capstone_sys::*;
 
 /// Representation of the array of instructions returned by disasm
@@ -67,8 +67,8 @@ impl<'a> Iterator for InstructionIterator<'a> {
 /// A wrapper for the raw capstone-sys instruction
 pub struct Insn(pub(crate) cs_insn);
 
-/// A wrapper for the raw capstone-sys detail struct, which contains register information in addition
-/// to architecture specific information
+/// Contains extra information about an instruction such as register reads in
+/// addition to architecture-specific information
 pub struct Detail<'a>(pub(crate) &'a cs_detail);
 
 impl Insn {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,18 @@
 //! Bindings to the [capstone library][upstream] disassembly framework.
-//! 
+//!
 //! This crate is a wrapper around the
 //! [Capstone disassembly library](http://www.capstone-engine.org/),
 //! a "lightweight multi-platform, multi-architecture disassembly framework."
 //!
-//! The `Capstone` struct is the main interface to the library.
+//! The [`Capstone`](struct.Capstone.html) struct is the main interface to the library.
 //!
 //! ```rust
 //! extern crate capstone;
+//! use capstone::prelude::*;
 //!
 //! const CODE: &'static [u8] = b"\x55\x48\x8b\x05\xb8\x13\x00\x00";
 //! fn main() {
-//!     match capstone::Capstone::new(capstone::Arch::X86, capstone::Mode::LittleEndian) {
+//!     match Capstone::new().x86().mode(arch::x86::ArchMode::Mode32).build() {
 //!         Ok(cs) => {
 //!             match cs.disasm_all(CODE, 0x1000) {
 //!                 Ok(insns) => {
@@ -47,28 +48,50 @@
 extern crate capstone_sys;
 extern crate libc;
 
+pub mod arch;
 mod capstone;
 mod constants;
-mod instruction;
 mod error;
+mod instruction;
 
 pub use capstone::*;
 pub use constants::*;
 pub use instruction::*;
 pub use error::*;
 
+/// Contains items that you probably want to always import
+///
+/// For example:
+///
+/// ```
+/// use capstone::prelude::*;
+/// ```
+pub mod prelude {
+    pub use {Capstone, CsResult};
+    pub use arch::{self, BuildsCapstone, BuildsCapstoneEndian, BuildsCapstoneExtraMode,
+                   BuildsCapstoneSyntax};
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::HashSet;
     use capstone_sys::cs_group_type;
     use super::*;
+    use super::arch::*;
 
     const X86_CODE: &'static [u8] = b"\x55\x48\x8b\x05\xb8\x13\x00\x00";
     const ARM_CODE: &'static [u8] = b"\x55\x48\x8b\x05\xb8\x13\x00\x00";
 
+    // Aliases for group types
+    const JUMP: cs_group_type = cs_group_type::CS_GRP_JUMP;
+    const CALL: cs_group_type = cs_group_type::CS_GRP_CALL;
+    const RET: cs_group_type = cs_group_type::CS_GRP_RET;
+    const INT: cs_group_type = cs_group_type::CS_GRP_INT;
+    const IRET: cs_group_type = cs_group_type::CS_GRP_IRET;
+
     #[test]
     fn test_x86_simple() {
-        match Capstone::new(Arch::X86, Mode::LittleEndian) {
+        match Capstone::new().x86().mode(x86::ArchMode::Mode64).build() {
             Ok(cs) => {
                 match cs.disasm_all(X86_CODE, 0x1000) {
                     Ok(insns) => {
@@ -82,8 +105,6 @@ mod test {
 
                         assert_eq!(is[0].bytes(), b"\x55");
                         assert_eq!(is[1].bytes(), b"\x48\x8b\x05\xb8\x13\x00\x00");
-                        assert_eq!(is[0].address(), 0x1000);
-                        assert_eq!(is[1].address(), 0x1001);
                     }
                     Err(err) => assert!(false, "Couldn't disasm instructions: {}", err),
                 }
@@ -96,7 +117,7 @@ mod test {
 
     #[test]
     fn test_arm_simple() {
-        match Capstone::new(Arch::ARM, Mode::LittleEndian) {
+        match Capstone::new().arm().mode(arm::ArchMode::Arm).build() {
             Ok(cs) => {
                 match cs.disasm_all(ARM_CODE, 0x1000) {
                     Ok(insns) => {
@@ -119,13 +140,17 @@ mod test {
 
     #[test]
     fn test_arm64_none() {
-        let cs = Capstone::new(Arch::ARM64, Mode::LittleEndian).unwrap();
+        let cs = Capstone::new()
+            .arm64()
+            .mode(arm64::ArchMode::Arm)
+            .build()
+            .unwrap();
         assert!(cs.disasm_all(ARM_CODE, 0x1000).is_err());
     }
 
     #[test]
     fn test_x86_names() {
-        match Capstone::new(Arch::X86, Mode::LittleEndian) {
+        match Capstone::new().x86().mode(x86::ArchMode::Mode32).build() {
             Ok(cs) => {
                 let reg_id = 1;
                 match cs.reg_name(reg_id) {
@@ -163,63 +188,95 @@ mod test {
 
     #[test]
     fn test_detail_false_fail() {
-        let mut cs = Capstone::new(Arch::X86, Mode::Mode64)
-                .unwrap();
+        let mut cs = Capstone::new()
+            .x86()
+            .mode(x86::ArchMode::Mode64)
+            .build()
+            .unwrap();
         cs.set_detail(false).unwrap();
         let insns: Vec<_> = cs.disasm_all(X86_CODE, 0x1000).unwrap().iter().collect();
-        assert_eq!(cs.insn_belongs_to_group(&insns[0], 0),
-                   Err(Error::Capstone(CapstoneError::DetailOff)));
-        assert_eq!(cs.insn_belongs_to_group(&insns[1], 0),
-                   Err(Error::Capstone(CapstoneError::DetailOff)));
+        assert_eq!(
+            cs.insn_belongs_to_group(&insns[0], 0),
+            Err(Error::Capstone(CapstoneError::DetailOff))
+        );
+        assert_eq!(
+            cs.insn_belongs_to_group(&insns[1], 0),
+            Err(Error::Capstone(CapstoneError::DetailOff))
+        );
     }
 
     #[test]
     fn test_detail_true() {
-        let mut cs = Capstone::new(Arch::X86,
-                                             Mode::Mode64)
-                .unwrap();
-        cs.set_detail(true).unwrap();
-        let insns: Vec<_> = cs.disasm_all(X86_CODE, 0x1000).unwrap().iter().collect();
-        let insn_group_ids = [cs_group_type::CS_GRP_JUMP,
-                              cs_group_type::CS_GRP_CALL,
-                              cs_group_type::CS_GRP_RET,
-                              cs_group_type::CS_GRP_INT,
-                              cs_group_type::CS_GRP_IRET];
-        for insn_idx in 0..1 + 1 {
-            for insn_group_id in &insn_group_ids {
-                assert_eq!(cs.insn_belongs_to_group(&insns[insn_idx], *insn_group_id as u64),
-                           Ok(false));
+        let mut cs1 = Capstone::new()
+            .x86()
+            .mode(x86::ArchMode::Mode64)
+            .build()
+            .unwrap();
+        cs1.set_detail(true).unwrap();
+
+        let cs2 = Capstone::new()
+            .x86()
+            .mode(x86::ArchMode::Mode64)
+            .detail(true)
+            .build()
+            .unwrap();
+
+        for cs in [cs1, cs2].iter_mut() {
+            let insns: Vec<_> = cs.disasm_all(X86_CODE, 0x1000).unwrap().iter().collect();
+            let insn_group_ids = [
+                cs_group_type::CS_GRP_JUMP,
+                cs_group_type::CS_GRP_CALL,
+                cs_group_type::CS_GRP_RET,
+                cs_group_type::CS_GRP_INT,
+                cs_group_type::CS_GRP_IRET,
+            ];
+            for insn_idx in 0..1 + 1 {
+                for insn_group_id in &insn_group_ids {
+                    assert_eq!(
+                        cs.insn_belongs_to_group(&insns[insn_idx], *insn_group_id as u64),
+                        Ok(false)
+                    );
+                }
             }
         }
     }
 
+    fn test_instruction_helper(
+        cs: &Capstone,
+        insn: &Insn,
+        mnemonic_name: &str,
+        bytes: &[u8],
+        has_default_syntax: bool,
+    ) {
+        // Check mnemonic
+        if has_default_syntax {
+            // insn_name() does not respect current syntax
+            // does not always match the internal mnemonic
+            cs.insn_name(insn.id() as u64).expect(
+                "Failed to get instruction name",
+            );
+        }
+        assert_eq!(
+            mnemonic_name,
+            insn.mnemonic().expect("Failed to get mnemonic"),
+            "Did not match contained insn.mnemonic"
+        );
+
+        // Assert instruction bytes match
+        assert_eq!(bytes, insn.bytes());
+    }
+
     /// Assert instruction belongs or does not belong to groups, testing both insn_belongs_to_group
     /// and insn_group_ids
-    fn test_x86_instruction_detail_helper(mnemonic_name: &str,
-                                          bytes: &[u8],
-                                          expected_groups: &[cs_group_type]) {
-        let mut cs = Capstone::new(Arch::X86,
-                                             Mode::Mode64)
-                .expect("Failed to create capstone handle");
-
-        // Details required to get groups information
-        cs.set_detail(true).unwrap();
-
-        // Disassemble instructions
-        let insns: Vec<_> = cs.disasm_all(bytes, 0x1000)
-            .expect("Failed to disassemble")
-            .iter()
-            .collect();
-
-        // Check number of instructions
-        assert_eq!(insns.len(), 1, "Expected exactly 1 instruction");
-
-        let insn = &insns[0];
-
-        // Check mnemonic
-        assert_eq!(mnemonic_name,
-                   cs.insn_name(insn.id() as u64)
-                       .expect("Failed to get instruction name"));
+    fn test_instruction_group_helper(
+        cs: &Capstone,
+        insn: &Insn,
+        mnemonic_name: &str,
+        bytes: &[u8],
+        expected_groups: &[cs_group_type],
+        has_default_syntax: bool,
+    ) {
+        test_instruction_helper(&cs, insn, mnemonic_name, bytes, has_default_syntax);
 
         // Assert expected instruction groups is a subset of computed groups through ids
         let instruction_group_ids: HashSet<u8> = cs.insn_groups(&insn)
@@ -228,10 +285,12 @@ mod test {
             .map(|&x| x)
             .collect();
         let expected_groups_ids: HashSet<u8> = expected_groups.iter().map(|&x| x as u8).collect();
-        assert!(expected_groups_ids.is_subset(&instruction_group_ids),
-                "Expected groups {:?} does NOT match computed insn groups {:?} with ",
-                expected_groups_ids,
-                instruction_group_ids);
+        assert!(
+            expected_groups_ids.is_subset(&instruction_group_ids),
+            "Expected groups {:?} does NOT match computed insn groups {:?} with ",
+            expected_groups_ids,
+            instruction_group_ids
+        );
 
         // Assert expected instruction groups is a subset of computed groups through enum
         let instruction_groups_set: HashSet<u8> = cs.insn_groups(&insn)
@@ -239,43 +298,48 @@ mod test {
             .iter()
             .map(|&x| x)
             .collect();
-        let expected_groups_set: HashSet<u8> =
-            expected_groups.iter().map(|&x| x as u8).collect();
-        assert!(expected_groups_set.is_subset(&instruction_groups_set),
-                "Expected groups {:?} does NOT match computed insn groups {:?}",
-                expected_groups_set,
-                instruction_groups_set);
-
+        let expected_groups_set: HashSet<u8> = expected_groups.iter().map(|&x| x as u8).collect();
+        assert!(
+            expected_groups_set.is_subset(&instruction_groups_set),
+            "Expected groups {:?} does NOT match computed insn groups {:?}",
+            expected_groups_set,
+            instruction_groups_set
+        );
 
         // Create sets of expected groups and unexpected groups
-        let instruction_types: HashSet<cs_group_type> = [cs_group_type::CS_GRP_JUMP,
-                                                         cs_group_type::CS_GRP_CALL,
-                                                         cs_group_type::CS_GRP_RET,
-                                                         cs_group_type::CS_GRP_INT,
-                                                         cs_group_type::CS_GRP_IRET]
-                .iter()
-                .cloned()
-                .collect();
+        let instruction_types: HashSet<cs_group_type> = [
+            cs_group_type::CS_GRP_JUMP,
+            cs_group_type::CS_GRP_CALL,
+            cs_group_type::CS_GRP_RET,
+            cs_group_type::CS_GRP_INT,
+            cs_group_type::CS_GRP_IRET,
+        ].iter()
+            .cloned()
+            .collect();
         let expected_groups_set: HashSet<cs_group_type> =
             expected_groups.iter().map(|&x| x).collect();
         let not_belong_groups = instruction_types.difference(&expected_groups_set);
 
         // Assert instruction belongs to belong_groups
         for &belong_group in expected_groups {
-            assert_eq!(Ok(true),
-                       cs.insn_belongs_to_group(&insn, belong_group as u64),
-                       "{:?} does NOT BELONG to group {:?}, but the instruction SHOULD",
-                       insn,
-                       belong_group);
+            assert_eq!(
+                Ok(true),
+                cs.insn_belongs_to_group(&insn, belong_group as u64),
+                "{:?} does NOT BELONG to group {:?}, but the instruction SHOULD",
+                insn,
+                belong_group
+            );
         }
 
         // Assert instruction does not belong to not_belong_groups
         for &not_belong_group in not_belong_groups {
-            assert_eq!(Ok(false),
-                       cs.insn_belongs_to_group(&insn, not_belong_group as u64),
-                       "{:?} BELONGS to group {:?}, but the instruction SHOULD NOT",
-                       insn,
-                       not_belong_group);
+            assert_eq!(
+                Ok(false),
+                cs.insn_belongs_to_group(&insn, not_belong_group as u64),
+                "{:?} BELONGS to group {:?}, but the instruction SHOULD NOT",
+                insn,
+                not_belong_group
+            );
         }
 
         // @todo: check read_registers
@@ -283,31 +347,241 @@ mod test {
         // @todo: check write_registers
     }
 
+    fn instructions_match_group(
+        cs: &mut Capstone,
+        expected_insns: &[(&str, &[u8], &[cs_group_type])],
+        has_default_syntax: bool,
+    ) {
+        let insns_buf: Vec<u8> = expected_insns
+            .iter()
+            .flat_map(|&(_, bytes, _)| bytes)
+            .map(|x| *x)
+            .collect();
+
+        // Details required to get groups information
+        cs.set_detail(true).unwrap();
+
+
+        if expected_insns.len() == 0 {
+            // Input was empty, which will cause disasm_all() to fail
+            return;
+        }
+
+        let insns: Vec<_> = cs.disasm_all(&insns_buf, 0x1000)
+            .expect("Failed to disassemble")
+            .iter()
+            .collect();
+
+        // Check number of instructions
+        assert_eq!(insns.len(), expected_insns.len());
+
+        for (insn, &(expected_mnemonic, expected_bytes, expected_groups)) in
+            insns.iter().zip(expected_insns)
+        {
+            test_instruction_group_helper(
+                &cs,
+                insn,
+                expected_mnemonic,
+                expected_bytes,
+                expected_groups,
+                has_default_syntax,
+            )
+        }
+    }
+
+    fn instructions_match(
+        cs: &mut Capstone,
+        expected_insns: &[(&str, &[u8])],
+        has_default_syntax: bool,
+    ) {
+        let insns_buf: Vec<u8> = expected_insns
+            .iter()
+            .flat_map(|&(_, bytes)| bytes)
+            .map(|x| *x)
+            .collect();
+
+        // Details required to get groups information
+        cs.set_detail(true).unwrap();
+
+
+        if expected_insns.len() == 0 {
+            // Input was empty, which will cause disasm_all() to fail
+            return;
+        }
+
+        let insns: Vec<_> = cs.disasm_all(&insns_buf, 0x1000)
+            .expect("Failed to disassemble")
+            .iter()
+            .collect();
+
+        // Check number of instructions
+        assert_eq!(insns.len(), expected_insns.len());
+
+        for (insn, &(expected_mnemonic, expected_bytes)) in insns.iter().zip(expected_insns) {
+            test_instruction_helper(
+                &cs,
+                insn,
+                expected_mnemonic,
+                expected_bytes,
+                has_default_syntax,
+            )
+        }
+    }
+
     #[test]
     fn test_instruction_group_ids() {
-        let jump = cs_group_type::CS_GRP_JUMP;
-        let call = cs_group_type::CS_GRP_CALL;
-        let ret = cs_group_type::CS_GRP_RET;
-        let int = cs_group_type::CS_GRP_INT;
-        let iret = cs_group_type::CS_GRP_IRET;
+        let expected_insns: &[(&str, &[u8], &[cs_group_type])] =
+            &[
+                ("nop", b"\x90", &[]),
+                ("je", b"\x74\x05", &[JUMP]),
+                ("call", b"\xe8\x28\x07\x00\x00", &[CALL]),
+                ("ret", b"\xc3", &[RET]),
+                ("syscall", b"\x0f\x05", &[INT]),
+                ("iretd", b"\xcf", &[IRET]),
+                ("sub", b"\x48\x83\xec\x08", &[]),
+                ("test", b"\x48\x85\xc0", &[]),
+                ("mov", b"\x48\x8b\x05\x95\x4a\x4d\x00", &[]),
+                ("mov", b"\xb9\x04\x02\x00\x00", &[]),
+            ];
 
-        test_x86_instruction_detail_helper("nop", b"\x90", &[]);
-        test_x86_instruction_detail_helper("je", b"\x74\x05", &[jump]);
-        test_x86_instruction_detail_helper("call", b"\xe8\x28\x07\x00\x00", &[call]);
-        test_x86_instruction_detail_helper("ret", b"\xc3", &[ret]);
-        test_x86_instruction_detail_helper("syscall", b"\x0f\x05", &[int]);
-        test_x86_instruction_detail_helper("iretd", b"\xcf", &[iret]);
-        test_x86_instruction_detail_helper("sub", b"\x48\x83\xec\x08", &[]);
-        test_x86_instruction_detail_helper("test", b"\x48\x85\xc0", &[]);
-        test_x86_instruction_detail_helper("mov", b"\x48\x8b\x05\x95\x4a\x4d\x00", &[]);
-        test_x86_instruction_detail_helper("mov", b"\xb9\x04\x02\x00\x00", &[]);
+        let mut cs = Capstone::new()
+            .x86()
+            .mode(x86::ArchMode::Mode64)
+            .build()
+            .unwrap();
+        instructions_match_group(&mut cs, expected_insns, true);
+    }
+
+    fn test_insns_match(cs: &mut Capstone, insns: &[(&str, &[u8])]) {
+        for &(mnemonic, bytes) in insns.iter() {
+            let insns = cs.disasm_all(bytes, 0x1000).unwrap();
+            assert_eq!(insns.len(), 1);
+            let insn = insns.iter().next().unwrap();
+            assert_eq!(insn.mnemonic(), Some(mnemonic));
+        }
+    }
+
+    fn test_extra_mode_helper(
+        arch: Arch,
+        mode: Mode,
+        extra_mode: &[ExtraMode],
+        valid_both_insns: &[(&str, &[u8])],
+        valid_extra_mode: &[(&str, &[u8])],
+    ) {
+        let extra_mode = extra_mode.iter().map(|x| *x);
+        let mut cs = Capstone::new_raw(arch, mode, extra_mode, None).unwrap();
+
+        test_insns_match(&mut cs, valid_both_insns);
+
+        for &(_, _) in valid_extra_mode.iter() {
+            // Capstone will disassemble instructions not allowed by the current mode
+            // assert!(
+            //     cs.disasm_all(bytes, 0x1000).is_err(),
+            //     "Disassembly succeeded when on instruction when it should not have for {:?}",
+            //     bytes);
+        }
+
+        test_insns_match(&mut cs, valid_both_insns);
+        test_insns_match(&mut cs, valid_extra_mode);
+    }
+
+    #[test]
+    fn test_extra_mode() {
+        test_extra_mode_helper(
+            Arch::ARM,
+            Mode::Arm,
+            &[ExtraMode::V8],
+            &[("str", b"\x04\xe0\x2d\xe5")],
+            &[("vcvtt.f64.f16", b"\xe0\x3b\xb2\xee")],
+        );
+    }
+
+    fn test_arch_mode_endian_insns(
+        cs: &mut Capstone,
+        arch: Arch,
+        mode: Mode,
+        endian: Option<Endian>,
+        extra_mode: &[ExtraMode],
+        insns: &[(&str, &[u8])],
+    ) {
+        let expected_insns: Vec<(&str, &[u8])> = insns
+            .iter()
+            .map(|&(mnemonic, bytes)| (mnemonic, bytes))
+            .collect();
+
+        let extra_mode = extra_mode.iter().map(|x| *x);
+        let mut cs_raw = Capstone::new_raw(arch, mode, extra_mode, endian).unwrap();
+
+        instructions_match(&mut cs_raw, expected_insns.as_slice(), true);
+        instructions_match(cs, expected_insns.as_slice(), true);
+    }
+
+    #[test]
+    fn test_syntax() {
+        let expected_insns: &[(&str, &str, &[u8], &[cs_group_type])] =
+            &[
+                ("nop", "nop", b"\x90", &[]),
+                ("je", "je", b"\x74\x05", &[JUMP]),
+                ("call", "callq", b"\xe8\x28\x07\x00\x00", &[CALL]),
+                ("ret", "retq", b"\xc3", &[RET]),
+                ("syscall", "syscall", b"\x0f\x05", &[INT]),
+                ("iretd", "iretl", b"\xcf", &[IRET]),
+                ("sub", "subq", b"\x48\x83\xec\x08", &[]),
+                ("test", "testq", b"\x48\x85\xc0", &[]),
+                ("mov", "movq", b"\x48\x8b\x05\x95\x4a\x4d\x00", &[]),
+                ("mov", "movl", b"\xb9\x04\x02\x00\x00", &[]),
+            ];
+
+        let expected_insns_intel: Vec<(&str, &[u8], &[cs_group_type])> = expected_insns
+            .iter()
+            .map(|&(mnemonic, _, bytes, groups)| (mnemonic, bytes, groups))
+            .collect();
+        let expected_insns_att: Vec<(&str, &[u8], &[cs_group_type])> = expected_insns
+            .iter()
+            .map(|&(_, mnemonic, bytes, groups)| (mnemonic, bytes, groups))
+            .collect();
+
+        let mut cs = Capstone::new()
+            .x86()
+            .mode(x86::ArchMode::Mode64)
+            .syntax(x86::ArchSyntax::Intel)
+            .build()
+            .unwrap();
+        instructions_match_group(&mut cs, &expected_insns_intel, true);
+
+        cs.set_syntax(Syntax::Intel).unwrap();
+        instructions_match_group(&mut cs, &expected_insns_intel, true);
+
+        cs.set_syntax(Syntax::Att).unwrap();
+        instructions_match_group(&mut cs, &expected_insns_att, false);
+    }
+
+    // @todo(tmfink) test invalid syntax once we check for invalid options
+    #[test]
+    fn test_invalid_syntax() {
+        // These do no support any syntax change
+        let rules = [(Arch::ARM, Mode::Thumb)];
+        let syntaxes = [
+            // Syntax::Intel,
+            // Syntax::Att,
+            // Syntax::NoRegName,
+        ];
+
+        for &(arch, mode) in rules.iter() {
+            let mut cs = Capstone::new_raw(arch, mode, NO_EXTRA_MODE, None).unwrap();
+            for &syntax in syntaxes.iter() {
+                let result = cs.set_syntax(syntax);
+                assert!(result.is_err(), "Expected Err, got {:?}", result);
+            }
+        }
     }
 
     #[test]
     fn test_invalid_mode() {
-        match Capstone::new(Arch::ALL, Mode::Mode64) {
-            Ok(_) => assert!(false, "Invalid open worked"),
-            Err(err) => assert!(err == Error::Capstone(CapstoneError::UnsupportedArch)),
+        if let Err(err) = Capstone::new_raw(Arch::PPC, Mode::Thumb, NO_EXTRA_MODE, None) {
+            assert_eq!(err, Error::Capstone(CapstoneError::InvalidMode));
+        } else {
+            panic!("Should fail to create given modes");
         }
     }
 
@@ -321,16 +595,17 @@ mod test {
 
     #[test]
     fn test_capstone_supports_arch() {
-        let architectures = vec![Arch::ARM,
-                                 Arch::ARM64,
-                                 Arch::MIPS,
-                                 Arch::X86,
-                                 Arch::PPC,
-                                 Arch::SPARC,
-                                 Arch::SYSZ,
-                                 Arch::XCORE,
-                                 // Arch::M68K,
-                                 ];
+        let architectures = vec![
+            Arch::ARM,
+            Arch::ARM64,
+            Arch::MIPS,
+            Arch::X86,
+            Arch::PPC,
+            Arch::SPARC,
+            Arch::SYSZ,
+            Arch::XCORE,
+            // Arch::M68K,
+        ];
 
         println!("Supported architectures");
         for arch in architectures {
@@ -342,5 +617,428 @@ mod test {
     #[test]
     fn test_capstone_is_diet() {
         println!("Capstone is diet: {}", Capstone::is_diet());
+    }
+
+    #[test]
+    fn test_arch_arm() {
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .arm()
+                .mode(arm::ArchMode::Arm)
+                .build()
+                .unwrap(),
+            Arch::ARM,
+            Mode::Arm,
+            None,
+            &[],
+            &[
+                ("bl", b"\xed\xff\xff\xeb"),
+                ("str", b"\x04\xe0\x2d\xe5"),
+                ("andeq", b"\x00\x00\x00\x00"),
+                ("str", b"\xe0\x83\x22\xe5"),
+                ("mcreq", b"\xf1\x02\x03\x0e"),
+                ("mov", b"\x00\x00\xa0\xe3"),
+                ("strb", b"\x02\x30\xc1\xe7"),
+                ("cmp", b"\x00\x00\x53\xe3"),
+                ("setend", b"\x00\x02\x01\xf1"),
+                ("ldm", b"\x05\x40\xd0\xe8"),
+                ("strdeq", b"\xf4\x80\x00\x00"),
+            ],
+        );
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .arm()
+                .mode(arm::ArchMode::Thumb)
+                .build()
+                .unwrap(),
+            Arch::ARM,
+            Mode::Thumb,
+            None,
+            &[],
+            &[
+                ("bx", b"\x70\x47"),
+                ("blx", b"\x00\xf0\x10\xe8"),
+                ("mov", b"\xeb\x46"),
+                ("sub", b"\x83\xb0"),
+                ("ldr", b"\xc9\x68"),
+                ("cbz", b"\x1f\xb1"),
+                ("wfi", b"\x30\xbf"),
+                ("cpsie.w", b"\xaf\xf3\x20\x84"),
+                ("tbb", b"\xd1\xe8\x00\xf0"),
+                ("movs", b"\xf0\x24"),
+                ("lsls", b"\x04\x07"),
+                ("subs", b"\x1f\x3c"),
+                ("stm", b"\xf2\xc0"),
+                ("movs", b"\x00\x00"),
+                ("mov.w", b"\x4f\xf0\x00\x01"),
+                ("ldr", b"\x46\x6c"),
+            ],
+        );
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .arm()
+                .mode(arm::ArchMode::Thumb)
+                .build()
+                .unwrap(),
+            Arch::ARM,
+            Mode::Thumb,
+            None,
+            &[],
+            &[
+                ("mov.w", b"\x4f\xf0\x00\x01"),
+                ("pop.w", b"\xbd\xe8\x00\x88"),
+                ("tbb", b"\xd1\xe8\x00\xf0"),
+                ("it", b"\x18\xbf"),
+                ("iteet", b"\xad\xbf"),
+                ("vdupne.8", b"\xf3\xff\x0b\x0c"),
+                ("msr", b"\x86\xf3\x00\x89"),
+                ("msr", b"\x80\xf3\x00\x8c"),
+                ("sxtb.w", b"\x4f\xfa\x99\xf6"),
+                ("vaddw.u16", b"\xd0\xff\xa2\x01"),
+            ],
+        );
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .arm()
+                .mode(arm::ArchMode::Thumb)
+                .extra_mode([arm::ArchExtraMode::MClass].iter().map(|x| *x))
+                .build()
+                .unwrap(),
+            Arch::ARM,
+            Mode::Thumb,
+            None,
+            &[ExtraMode::MClass],
+            &[("mrs", b"\xef\xf3\x02\x80")],
+        );
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .arm()
+                .mode(arm::ArchMode::Arm)
+                .extra_mode([arm::ArchExtraMode::V8].iter().map(|x| *x))
+                .build()
+                .unwrap(),
+            Arch::ARM,
+            Mode::Arm,
+            None,
+            &[ExtraMode::V8],
+            &[
+                ("vcvtt.f64.f16", b"\xe0\x3b\xb2\xee"),
+                ("crc32b", b"\x42\x00\x01\xe1"),
+                ("dmb", b"\x51\xf0\x7f\xf5"),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_arch_arm64() {
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .arm64()
+                .mode(arm64::ArchMode::Arm)
+                .build()
+                .unwrap(),
+            Arch::ARM64,
+            Mode::Arm,
+            None,
+            &[],
+            &[
+                ("mrs", b"\x09\x00\x38\xd5"),
+                ("msr", b"\xbf\x40\x00\xd5"),
+                ("msr", b"\x0c\x05\x13\xd5"),
+                ("tbx", b"\x20\x50\x02\x0e"),
+                ("scvtf", b"\x20\xe4\x3d\x0f"),
+                ("fmla", b"\x00\x18\xa0\x5f"),
+                ("fmov", b"\xa2\x00\xae\x9e"),
+                ("dsb", b"\x9f\x37\x03\xd5"),
+                ("dmb", b"\xbf\x33\x03\xd5"),
+                ("isb", b"\xdf\x3f\x03\xd5"),
+                ("mul", b"\x21\x7c\x02\x9b"),
+                ("lsr", b"\x21\x7c\x00\x53"),
+                ("sub", b"\x00\x40\x21\x4b"),
+                ("ldr", b"\xe1\x0b\x40\xb9"),
+                ("cneg", b"\x20\x04\x81\xda"),
+                ("add", b"\x20\x08\x02\x8b"),
+                ("ldr", b"\x10\x5b\xe8\x3c"),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_arch_mips() {
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .mips()
+                .mode(mips::ArchMode::Mips32R6)
+                .build()
+                .unwrap(),
+            Arch::MIPS,
+            Mode::Mips32R6,
+            Some(Endian::Little),
+            &[],
+            &[("ori", b"\x56\x34\x21\x34"), ("srl", b"\xc2\x17\x01\x00")],
+        );
+
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .mips()
+                .mode(mips::ArchMode::Mips32R6)
+                .endian(Endian::Big)
+                .build()
+                .unwrap(),
+            Arch::MIPS,
+            Mode::Mips32R6,
+            Some(Endian::Big),
+            &[],
+            &[
+                ("ori", b"\x34\x21\x34\x56"),
+                ("jal", b"\x0C\x10\x00\x97"),
+                ("nop", b"\x00\x00\x00\x00"),
+                ("addiu", b"\x24\x02\x00\x0c"),
+                ("lw", b"\x8f\xa2\x00\x00"),
+                ("ori", b"\x34\x21\x34\x56"),
+            ],
+        );
+
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .mips()
+                .mode(mips::ArchMode::Mips32R6)
+                .extra_mode([mips::ArchExtraMode::Micro].iter().map(|x| *x))
+                .endian(Endian::Big)
+                .build()
+                .unwrap(),
+            Arch::MIPS,
+            Mode::Mips32R6,
+            Some(Endian::Big),
+            &[ExtraMode::Micro],
+            &[
+                ("break", b"\x00\x07\x00\x07"),
+                ("wait", b"\x00\x11\x93\x7c"),
+                ("syscall", b"\x01\x8c\x8b\x7c"),
+                ("rotrv", b"\x00\xc7\x48\xd0"),
+            ],
+        );
+
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .mips()
+                .mode(mips::ArchMode::Mips32R6)
+                .endian(Endian::Big)
+                .build()
+                .unwrap(),
+            Arch::MIPS,
+            Mode::Mips32R6,
+            Some(Endian::Big),
+            &[],
+            &[
+                ("addiupc", b"\xec\x80\x00\x19"),
+                ("align", b"\x7c\x43\x22\xa0"),
+            ],
+        );
+    }
+
+
+    #[test]
+    fn test_arch_ppc() {
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .ppc()
+                .mode(ppc::ArchMode::Mode32)
+                .endian(Endian::Big)
+                .build()
+                .unwrap(),
+            Arch::PPC,
+            // Mode::Mode32,
+            Mode::Default,
+            Some(Endian::Big),
+            &[],
+            &[
+                ("bdnzla+", b"\x43\x20\x0c\x07"),
+                ("bdztla", b"\x41\x56\xff\x17"),
+                ("lwz", b"\x80\x20\x00\x00"),
+                ("lwz", b"\x80\x3f\x00\x00"),
+                ("vpkpx", b"\x10\x43\x23\x0e"),
+                ("stfs", b"\xd0\x44\x00\x80"),
+                ("crand", b"\x4c\x43\x22\x02"),
+                ("cmpwi", b"\x2d\x03\x00\x80"),
+                ("addc", b"\x7c\x43\x20\x14"),
+                ("mulhd.", b"\x7c\x43\x20\x93"),
+                ("bdnzlrl+", b"\x4f\x20\x00\x21"),
+                ("bgelrl-", b"\x4c\xc8\x00\x21"),
+                ("bne", b"\x40\x82\x00\x14"),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_arch_sparc() {
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .sparc()
+                .mode(sparc::ArchMode::Default)
+                .build()
+                .unwrap(),
+            Arch::SPARC,
+            Mode::Default,
+            None,
+            &[],
+            &[
+                ("cmp", b"\x80\xa0\x40\x02"),
+                ("jmpl", b"\x85\xc2\x60\x08"),
+                ("restore", b"\x85\xe8\x20\x01"),
+                ("restore", b"\x81\xe8\x00\x00"),
+                ("mov", b"\x90\x10\x20\x01"),
+                ("casx", b"\xd5\xf6\x10\x16"),
+                ("sethi", b"\x21\x00\x00\x0a"),
+                ("add", b"\x86\x00\x40\x02"),
+                ("nop", b"\x01\x00\x00\x00"),
+                ("bne", b"\x12\xbf\xff\xff"),
+                ("ba", b"\x10\xbf\xff\xff"),
+                ("add", b"\xa0\x02\x00\x09"),
+                ("fbg", b"\x0d\xbf\xff\xff"),
+                ("st", b"\xd4\x20\x60\x00"),
+                ("ldsb", b"\xd4\x4e\x00\x16"),
+                ("brnz,a,pn", b"\x2a\xc2\x80\x03"),
+            ],
+        );
+
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .sparc()
+                .mode(sparc::ArchMode::V9)
+                .build()
+                .unwrap(),
+            Arch::SPARC,
+            Mode::V9,
+            Some(Endian::Big),
+            &[],
+            &[
+                ("fcmps", b"\x81\xa8\x0a\x24"),
+                ("fstox", b"\x89\xa0\x10\x20"),
+                ("fqtoi", b"\x89\xa0\x1a\x60"),
+                ("fnegq", b"\x89\xa0\x00\xe0"),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_arch_systemz() {
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .sysz()
+                .mode(sysz::ArchMode::Default)
+                .build()
+                .unwrap(),
+            Arch::SYSZ,
+            Mode::Default,
+            None,
+            &[],
+            &[
+                ("adb", b"\xed\x00\x00\x00\x00\x1a"),
+                ("a", b"\x5a\x0f\x1f\xff"),
+                ("afi", b"\xc2\x09\x80\x00\x00\x00"),
+                ("br", b"\x07\xf7"),
+                ("xiy", b"\xeb\x2a\xff\xff\x7f\x57"),
+                ("xy", b"\xe3\x01\xff\xff\x7f\x57"),
+                ("stmg", b"\xeb\x00\xf0\x00\x00\x24"),
+                ("ear", b"\xb2\x4f\x00\x78"),
+                ("clije", b"\xec\x18\x00\x00\xc1\x7f"),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_arch_x86() {
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .x86()
+                .mode(x86::ArchMode::Mode16)
+                .build()
+                .unwrap(),
+            Arch::X86,
+            Mode::Mode16,
+            None,
+            &[],
+            &[
+                ("lea", b"\x8d\x4c\x32"),
+                ("or", b"\x08\x01"),
+                ("fadd", b"\xd8\x81\xc6\x34"),
+                ("adc", b"\x12\x00"),
+                ("add", b"\x00\x05"),
+                ("and", b"\x23\x01"),
+                ("add", b"\x00\x00"),
+                ("mov", b"\x36\x8b\x84\x91\x23"),
+                ("add", b"\x01\x00"),
+                ("add", b"\x00\x41\x8d"),
+                ("test", b"\x84\x39"),
+                ("mov", b"\x89\x67\x00"),
+                ("add", b"\x00\x8d\x87\x89"),
+                ("add", b"\x67\x00\x00"),
+                ("mov", b"\xb4\xc6"),
+            ],
+        );
+
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .x86()
+                .mode(x86::ArchMode::Mode32)
+                .build()
+                .unwrap(),
+            Arch::X86,
+            Mode::Mode32,
+            None,
+            &[],
+            &[
+                ("lea", b"\x8d\x4c\x32\x08"),
+                ("add", b"\x01\xd8"),
+                ("add", b"\x81\xc6\x34\x12\x00\x00"),
+                ("add", b"\x05\x23\x01\x00\x00"),
+                ("mov", b"\x36\x8b\x84\x91\x23\x01\x00\x00"),
+                ("inc", b"\x41"),
+                ("lea", b"\x8d\x84\x39\x89\x67\x00\x00"),
+                ("lea", b"\x8d\x87\x89\x67\x00\x00"),
+                ("mov", b"\xb4\xc6"),
+            ],
+        );
+
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .x86()
+                .mode(x86::ArchMode::Mode64)
+                .build()
+                .unwrap(),
+            Arch::X86,
+            Mode::Mode64,
+            None,
+            &[],
+            &[("push", b"\x55"), ("mov", b"\x48\x8b\x05\xb8\x13\x00\x00")],
+        );
+    }
+
+    #[test]
+    fn test_arch_xcore() {
+        test_arch_mode_endian_insns(
+            &mut Capstone::new()
+                .xcore()
+                .mode(xcore::ArchMode::Default)
+                .build()
+                .unwrap(),
+            Arch::XCORE,
+            Mode::Default,
+            None,
+            &[],
+            &[
+                ("get", b"\xfe\x0f"),
+                ("ldw", b"\xfe\x17"),
+                ("setd", b"\x13\x17"),
+                ("init", b"\xc6\xfe\xec\x17"),
+                ("divu", b"\x97\xf8\xec\x4f"),
+                ("lda16", b"\x1f\xfd\xec\x37"),
+                ("ldw", b"\x07\xf2\x45\x5b"),
+                ("lmul", b"\xf9\xfa\x02\x06"),
+                ("add", b"\x1b\x10"),
+                ("ldaw", b"\x09\xfd\xec\xa7"),
+            ],
+        );
     }
 }


### PR DESCRIPTION
Refactors the API, including:
* Partition `Mode` enum into:
    - `Mode`: referred to as "basic_mode" by [Capstone documentation](http://www.capstone-engine.org/lang_c.html)
        - Example: `Arm`/`Thumb`, `32`/`64`.
    - `ExtraMode`: "Extra Mode" in Capstone documentation
        - Example: Arm `V8`, Sparc `V9`
    - `Endian`: `big`/`little`
* Separate `new()` and `new_raw()` for `Capstone`
    - `new()` uses the builder pattern to ensure that only valid values are passed for mode, endian, extra_mode, etc.
        - `Capstone::new().x86().mode(x86::ArchMode::Mode64).syntax(x86::ArchSyntax::Intel).build()`
        - `Capstone::new().ppc().mode(ppc::ArchMode::Mode32).endian(Endian::Big).build()`
    - `new_raw()` has an API similar the original `new()`
        - `Capstone::new_raw(Arch::X86, Mode::Mode64, NO_EXTRA_MODE, None)`
        - `Capstone::new_raw(Arch::PPC, Mode::Default, NO_EXTRA_MODE, Some(Endian::Big))`
* Add setters to modify mode, syntax, etc.
    - Handles issue #12 

Private changes:
* Add tests for each architecture

Todo:
- [X] Use builder pattern with traits
- [x] ~~Run-time checks to ensure that valid values are passed to `new_raw()`, `set_mode()`, etc.~~ (save for future work)
- [x] ~~Expose more of the architecture-specific `detail` structure~~ (save for future work)
- [x] Put architecture modules under `arch::` module