### PR TITLE
Return empty instructions instead of an error

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -13,14 +13,23 @@ pub struct Instructions {
 }
 
 impl Instructions {
-    pub unsafe fn from_raw_parts(ptr: *mut cs_insn, len: isize) -> Instructions {
+    pub(crate) unsafe fn from_raw_parts(ptr: *mut cs_insn, len: isize) -> Instructions {
         Instructions { ptr: ptr, len: len }
     }
 
+    pub(crate) fn new_empty() -> Instructions {
+        Instructions {
+            ptr: ptr::null_mut(),
+            len: 0,
+        }
+    }
+
+    /// Get number of instructions
     pub fn len(&self) -> isize {
         self.len
     }
 
+    /// Iterator over instructions
     pub fn iter(&self) -> InstructionIterator {
         InstructionIterator {
             insns: self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ mod test {
             .mode(arm64::ArchMode::Arm)
             .build()
             .unwrap();
-        assert!(cs.disasm_all(ARM_CODE, 0x1000).is_err());
+        assert!(cs.disasm_all(ARM_CODE, 0x1000).unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Also makes `Instructions::from_raw_parts()` private (crate visibility).

Addresses #21