### PR TITLE
Marked instruction with std::maker::sync.

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -3,6 +3,7 @@ use std::os::raw::c_uint;
 use std::ptr;
 use std::str;
 use std::fmt::{self, Debug, Display, Error, Formatter};
+use std::marker::Sync;
 use capstone_sys::*;
 
 /// Representation of the array of instructions returned by disasm
@@ -48,6 +49,10 @@ impl Drop for Instructions {
             cs_free(self.ptr, self.len as usize);
         }
     }
+}
+
+unsafe impl Sync for Instructions {
+
 }
 
 /// An iterator over the instructions returned by disasm


### PR DESCRIPTION
This is done to make it usable by multiple threads. Capstone claims to be 'Thread-safe by design', so this should work.

Note that there are two flaky tests: They sometimes fail with and without my commit.

```
test test::test_instruction_group_ids ... FAILED
failures:

---- test::test_instruction_group_ids stdout ----
	thread 'test::test_instruction_group_ids' panicked at 'Expected groups {1} does NOT match computed insn groups {110} with ', src/lib.rs:287:8
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

```
test test::test_syntax ... FAILED
failures:

---- test::test_syntax stdout ----
	thread 'test::test_syntax' panicked at 'index 86 out of range for slice of length 8', src/libcore/slice/mod.rs:735:4
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```