### PR TITLE
Upgrade capstone-sys to 0.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 demo
 target
 Cargo.lock
+CHANGELOG.html
+README.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Architecture-specific detail API
-- Detail API unit tests
+- Architecture-specific detail API with `InsnDetail::arch_detail()` method
+- README badges!
+
+### Change
+- `Capstone::disasm()` (and related methods) return empty `Instructions` instead of an error
+- Make `Instructions::from_raw_parts()` private
 
 ## [0.2.0] - 2017-11-01
 ### Added
@@ -20,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Partition `Mode` enum into: `Mode`, `ExtraMode`, and `Endian`
 - Rename `Capstone` methods that return IDs to include `_ids` in name
     - Example: `read_registers()` renamed to `read_register_ids()`
+- Minimum Rust version is 1.20.0
+
+### Removed
+- `libc` dependency
 
 ## [0.1.0] - 2017-09-29
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.2.0"
 travis-ci = { repository = "capstone-rust/capstone-rs" }
 
 [dependencies]
-capstone-sys = "0.6.0"
+capstone-sys = "0.7.0"
 
 # Not actually a dependency, but this makes the more complicated examples work
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,5 @@ default = []
 
 use_system_capstone = ["capstone-sys/use_system_capstone"]
 build_capstone_cmake = ["capstone-sys/build_capstone_cmake"]
+build_capstone_cc = ["capstone-sys/build_capstone_cc"]
 use_bindgen = ["capstone-sys/use_bindgen"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,18 @@
 
 Bindings to the [capstone library][upstream] disassembly framework.
 
-There's an example in `demo.rs`, but as a sample:
+
+# Requirements
+
+`capstone-rs` uses the [`capstone-sys`](https://github.com/capstone-rust/capstone-sys) crate to provide the low-level bindings to the Capstone C library.
+
+See the [`capstone-sys`](https://github.com/capstone-rust/capstone-sys) GitHub page for the requirements and supported platforms.
+
+* Minimum Rust Version: `1.20.0` or later
+
+# Example
+
+The example from [`demo.rs`](examples/demo.rs):
 
 ```rust
 extern crate capstone;
@@ -111,21 +122,15 @@ Found 5 instructions
     insn groups:
 ```
 
-# Reporting Issues
-
-Please open a [Github issue](https://github.com/capstone-rust/capstone-rs/issues)
-
-# Demo
-
-You can run:
+You can the demo by running:
 
     cargo run --example=demo
 
 To produce a short demonstration. More complex demos welcome!
 
-# Minimum Rust Version
+# Reporting Issues
 
-`capstone-rs` requires Rust `1.20.0` or later.
+Please open a [Github issue](https://github.com/capstone-rust/capstone-rs/issues)
 
 # Author
 

--- a/scripts/build_readme.sh
+++ b/scripts/build_readme.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Builds README.md as html with GitHub style
+# tested with pandoc 2.1.1
+
+set -eux
+
+cd "$(dirname "$0")"
+
+build() {
+    base="$1"
+    pandoc \
+        -f gfm -t html5 \
+        --css github-md.css -Vpagetitle=capstone-sys \
+        --standalone --self-contained \
+        ${base}.md -o ${base}.html
+}
+
+build ../README
+build ../CHANGELOG

--- a/scripts/github-md.css
+++ b/scripts/github-md.css
@@ -1,0 +1,280 @@
+/* Andy Ferra
+ * andyferra/github.css
+ * https://gist.github.com/andyferra/2554919
+ */
+
+body {
+  font-family: Helvetica, arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  background-color: white;
+  padding: 30px; }
+
+body > *:first-child {
+  margin-top: 0 !important; }
+body > *:last-child {
+  margin-bottom: 0 !important; }
+
+a {
+  color: #4183C4; }
+a.absent {
+  color: #cc0000; }
+a.anchor {
+  display: block;
+  padding-left: 30px;
+  margin-left: -30px;
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0; }
+
+h1, h2, h3, h4, h5, h6 {
+  margin: 20px 0 10px;
+  padding: 0;
+  font-weight: bold;
+  -webkit-font-smoothing: antialiased;
+  cursor: text;
+  position: relative; }
+
+h1:hover a.anchor, h2:hover a.anchor, h3:hover a.anchor, h4:hover a.anchor, h5:hover a.anchor, h6:hover a.anchor {
+  text-decoration: none; }
+
+h1 tt, h1 code {
+  font-size: inherit; }
+
+h2 tt, h2 code {
+  font-size: inherit; }
+
+h3 tt, h3 code {
+  font-size: inherit; }
+
+h4 tt, h4 code {
+  font-size: inherit; }
+
+h5 tt, h5 code {
+  font-size: inherit; }
+
+h6 tt, h6 code {
+  font-size: inherit; }
+
+h1 {
+  font-size: 28px;
+  color: black; }
+
+h2 {
+  font-size: 24px;
+  border-bottom: 1px solid #cccccc;
+  color: black; }
+
+h3 {
+  font-size: 18px; }
+
+h4 {
+  font-size: 16px; }
+
+h5 {
+  font-size: 14px; }
+
+h6 {
+  color: #777777;
+  font-size: 14px; }
+
+p, blockquote, ul, ol, dl, li, table, pre {
+  margin: 15px 0; }
+
+hr {
+  border: 0 none;
+  color: #cccccc;
+  height: 4px;
+  padding: 0; }
+
+body > h2:first-child {
+  margin-top: 0;
+  padding-top: 0; }
+body > h1:first-child {
+  margin-top: 0;
+  padding-top: 0; }
+  body > h1:first-child + h2 {
+    margin-top: 0;
+    padding-top: 0; }
+body > h3:first-child, body > h4:first-child, body > h5:first-child, body > h6:first-child {
+  margin-top: 0;
+  padding-top: 0; }
+
+a:first-child h1, a:first-child h2, a:first-child h3, a:first-child h4, a:first-child h5, a:first-child h6 {
+  margin-top: 0;
+  padding-top: 0; }
+
+h1 p, h2 p, h3 p, h4 p, h5 p, h6 p {
+  margin-top: 0; }
+
+li p.first {
+  display: inline-block; }
+
+ul, ol {
+  padding-left: 30px; }
+
+ul :first-child, ol :first-child {
+  margin-top: 0; }
+
+ul :last-child, ol :last-child {
+  margin-bottom: 0; }
+
+dl {
+  padding: 0; }
+  dl dt {
+    font-size: 14px;
+    font-weight: bold;
+    font-style: italic;
+    padding: 0;
+    margin: 15px 0 5px; }
+    dl dt:first-child {
+      padding: 0; }
+    dl dt > :first-child {
+      margin-top: 0; }
+    dl dt > :last-child {
+      margin-bottom: 0; }
+  dl dd {
+    margin: 0 0 15px;
+    padding: 0 15px; }
+    dl dd > :first-child {
+      margin-top: 0; }
+    dl dd > :last-child {
+      margin-bottom: 0; }
+
+blockquote {
+  border-left: 4px solid #dddddd;
+  padding: 0 15px;
+  color: #777777; }
+  blockquote > :first-child {
+    margin-top: 0; }
+  blockquote > :last-child {
+    margin-bottom: 0; }
+
+table {
+  padding: 0; }
+  table tr {
+    border-top: 1px solid #cccccc;
+    background-color: white;
+    margin: 0;
+    padding: 0; }
+    table tr:nth-child(2n) {
+      background-color: #f8f8f8; }
+    table tr th {
+      font-weight: bold;
+      border: 1px solid #cccccc;
+      text-align: left;
+      margin: 0;
+      padding: 6px 13px; }
+    table tr td {
+      border: 1px solid #cccccc;
+      text-align: left;
+      margin: 0;
+      padding: 6px 13px; }
+    table tr th :first-child, table tr td :first-child {
+      margin-top: 0; }
+    table tr th :last-child, table tr td :last-child {
+      margin-bottom: 0; }
+
+img {
+  max-width: 100%; }
+
+span.frame {
+  display: block;
+  overflow: hidden; }
+  span.frame > span {
+    border: 1px solid #dddddd;
+    display: block;
+    float: left;
+    overflow: hidden;
+    margin: 13px 0 0;
+    padding: 7px;
+    width: auto; }
+  span.frame span img {
+    display: block;
+    float: left; }
+  span.frame span span {
+    clear: both;
+    color: #333333;
+    display: block;
+    padding: 5px 0 0; }
+span.align-center {
+  display: block;
+  overflow: hidden;
+  clear: both; }
+  span.align-center > span {
+    display: block;
+    overflow: hidden;
+    margin: 13px auto 0;
+    text-align: center; }
+  span.align-center span img {
+    margin: 0 auto;
+    text-align: center; }
+span.align-right {
+  display: block;
+  overflow: hidden;
+  clear: both; }
+  span.align-right > span {
+    display: block;
+    overflow: hidden;
+    margin: 13px 0 0;
+    text-align: right; }
+  span.align-right span img {
+    margin: 0;
+    text-align: right; }
+span.float-left {
+  display: block;
+  margin-right: 13px;
+  overflow: hidden;
+  float: left; }
+  span.float-left span {
+    margin: 13px 0 0; }
+span.float-right {
+  display: block;
+  margin-left: 13px;
+  overflow: hidden;
+  float: right; }
+  span.float-right > span {
+    display: block;
+    overflow: hidden;
+    margin: 13px auto 0;
+    text-align: right; }
+
+code, tt {
+  margin: 0 2px;
+  padding: 0 5px;
+  white-space: nowrap;
+  border: 1px solid #eaeaea;
+  background-color: #f8f8f8;
+  border-radius: 3px; }
+
+pre code {
+  margin: 0;
+  padding: 0;
+  white-space: pre;
+  border: none;
+  background: transparent; }
+
+.highlight pre {
+  background-color: #f8f8f8;
+  border: 1px solid #cccccc;
+  font-size: 13px;
+  line-height: 19px;
+  overflow: auto;
+  padding: 6px 10px;
+  border-radius: 3px; }
+
+pre {
+  background-color: #f8f8f8;
+  border: 1px solid #cccccc;
+  font-size: 13px;
+  line-height: 19px;
+  overflow: auto;
+  padding: 6px 10px;
+  border-radius: 3px; }
+  pre code, pre tt {
+    background-color: transparent;
+    border: none; }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,5 @@
 use capstone_sys::*;
 use capstone_sys::cs_arch::*;
-use capstone_sys::cs_mode::*;
 use capstone_sys::cs_opt_value::*;
 use std::convert::From;
 
@@ -10,7 +9,7 @@ use std::convert::From;
 macro_rules! define_cs_enum_wrapper {
     ( [
         $( #[$enum_attr:meta] )*
-        => $rust_enum:ident = $cs_enum:ident
+        => $rust_enum:ident = $cs_enum:ty
       ]
       $( $( #[$attr:meta] )*
       => $rust_variant:ident = $cs_variant:tt; )* ) => {
@@ -113,7 +112,7 @@ define_cs_enum_wrapper!(
 define_cs_enum_wrapper!(
     [
         /// Disassembly syntax
-        => Syntax = cs_opt_value
+        => Syntax = cs_opt_value::Type
     ]
     /// Intel syntax
     => Intel = CS_OPT_SYNTAX_INTEL;
@@ -123,7 +122,7 @@ define_cs_enum_wrapper!(
     => NoRegName = CS_OPT_SYNTAX_NOREGNAME;
 );
 
-pub(crate) struct OptValue(pub cs_opt_value);
+pub(crate) struct OptValue(pub cs_opt_value::Type);
 
 impl From<bool> for OptValue {
     fn from(value: bool) -> Self {
@@ -132,21 +131,5 @@ impl From<bool> for OptValue {
         } else {
             OptValue(cs_opt_value::CS_OPT_OFF)
         }
-    }
-}
-
-/// Representation of `cs_mode`. We use this to have a type that we can transmute() to that has
-/// the same memory representation.
-pub(crate) type CsModeRepr = i32;
-
-#[cfg(test)]
-mod test {
-    use capstone_sys::cs_mode;
-    use std::mem;
-    use super::CsModeRepr;
-
-    #[test]
-    fn test_cs_mode_size() {
-        assert_eq!(mem::size_of::<cs_mode>(), mem::size_of::<CsModeRepr>());
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,8 +33,8 @@ macro_rules! capstone_error_def {
             CustomError(&'static str),
         }
 
-        impl From<capstone_sys::cs_err> for Error {
-            fn from(err: capstone_sys::cs_err) -> Self {
+        impl From<capstone_sys::cs_err::Type> for Error {
+            fn from(err: capstone_sys::cs_err::Type) -> Self {
                 use self::Error::*;
                 use self::CapstoneError::*;
                 match err {
@@ -46,7 +46,7 @@ macro_rules! capstone_error_def {
             }
         }
 
-        impl From<CapstoneError> for capstone_sys::cs_err {
+        impl From<CapstoneError> for capstone_sys::cs_err::Type {
             fn from(err: CapstoneError) -> Self {
                 match err {
                     $(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,11 +216,11 @@ mod test {
     const ARM_CODE: &'static [u8] = b"\x55\x48\x8b\x05\xb8\x13\x00\x00";
 
     // Aliases for group types
-    const JUMP: cs_group_type = cs_group_type::CS_GRP_JUMP;
-    const CALL: cs_group_type = cs_group_type::CS_GRP_CALL;
-    const RET: cs_group_type = cs_group_type::CS_GRP_RET;
-    const INT: cs_group_type = cs_group_type::CS_GRP_INT;
-    const IRET: cs_group_type = cs_group_type::CS_GRP_IRET;
+    const JUMP: cs_group_type::Type = cs_group_type::CS_GRP_JUMP;
+    const CALL: cs_group_type::Type = cs_group_type::CS_GRP_CALL;
+    const RET: cs_group_type::Type = cs_group_type::CS_GRP_RET;
+    const INT: cs_group_type::Type = cs_group_type::CS_GRP_INT;
+    const IRET: cs_group_type::Type = cs_group_type::CS_GRP_IRET;
 
     #[test]
     fn test_x86_simple() {
@@ -442,7 +442,7 @@ mod test {
         insn: &Insn,
         mnemonic_name: &str,
         bytes: &[u8],
-        expected_groups: &[cs_group_type],
+        expected_groups: &[cs_group_type::Type],
         has_default_syntax: bool,
     ) {
         test_instruction_helper(&cs, insn, mnemonic_name, bytes, has_default_syntax);
@@ -478,7 +478,7 @@ mod test {
         );
 
         // Create sets of expected groups and unexpected groups
-        let instruction_types: HashSet<cs_group_type> = [
+        let instruction_types: HashSet<cs_group_type::Type> = [
             cs_group_type::CS_GRP_JUMP,
             cs_group_type::CS_GRP_CALL,
             cs_group_type::CS_GRP_RET,
@@ -487,7 +487,7 @@ mod test {
         ].iter()
             .cloned()
             .collect();
-        let expected_groups_set: HashSet<cs_group_type> =
+        let expected_groups_set: HashSet<cs_group_type::Type> =
             expected_groups.iter().map(|&x| x).collect();
         let not_belong_groups = instruction_types.difference(&expected_groups_set);
 
@@ -520,7 +520,7 @@ mod test {
 
     fn instructions_match_group(
         cs: &mut Capstone,
-        expected_insns: &[(&str, &[u8], &[cs_group_type])],
+        expected_insns: &[(&str, &[u8], &[cs_group_type::Type])],
         has_default_syntax: bool,
     ) {
         let insns_buf: Vec<u8> = expected_insns
@@ -628,7 +628,7 @@ mod test {
 
     #[test]
     fn test_instruction_group_ids() {
-        let expected_insns: &[(&str, &[u8], &[cs_group_type])] = &[
+        let expected_insns: &[(&str, &[u8], &[cs_group_type::Type])] = &[
             ("nop", b"\x90", &[]),
             ("je", b"\x74\x05", &[JUMP]),
             ("call", b"\xe8\x28\x07\x00\x00", &[CALL]),
@@ -756,7 +756,7 @@ mod test {
 
     #[test]
     fn test_syntax() {
-        let expected_insns: &[(&str, &str, &[u8], &[cs_group_type])] = &[
+        let expected_insns: &[(&str, &str, &[u8], &[cs_group_type::Type])] = &[
             ("nop", "nop", b"\x90", &[]),
             ("je", "je", b"\x74\x05", &[JUMP]),
             ("call", "callq", b"\xe8\x28\x07\x00\x00", &[CALL]),
@@ -769,11 +769,11 @@ mod test {
             ("mov", "movl", b"\xb9\x04\x02\x00\x00", &[]),
         ];
 
-        let expected_insns_intel: Vec<(&str, &[u8], &[cs_group_type])> = expected_insns
+        let expected_insns_intel: Vec<(&str, &[u8], &[cs_group_type::Type])> = expected_insns
             .iter()
             .map(|&(mnemonic, _, bytes, groups)| (mnemonic, bytes, groups))
             .collect();
-        let expected_insns_att: Vec<(&str, &[u8], &[cs_group_type])> = expected_insns
+        let expected_insns_att: Vec<(&str, &[u8], &[cs_group_type::Type])> = expected_insns
             .iter()
             .map(|&(_, mnemonic, bytes, groups)| (mnemonic, bytes, groups))
             .collect();


### PR DESCRIPTION
* Update capstone-sys to 0.7.0
    - Brings in Windows support (with `cc` crate)
    - Makes enum types more sane
    - Add `build_capstone_cc` pass-through feature
* Add script to build readme/changelog
* Update changelog