### PR TITLE
Allow alloc_system on current Rust.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Supports features in [`capstone-sys`](https://crates.io/crates/capstone-sys) tha
 ## Original Features
 
 `alloc_system`: use the system allocator instead of the default Rust allocator.
-This feature is *only* available on Nightly rust.
+This feature is *only* available on Rust 1.28 and later.
 Useful for running valgrind.
 
 # Reporting Issues

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,9 +121,6 @@
 //! [upstream]: http://capstone-engine.org/
 //!
 
-#![cfg_attr(feature = "alloc_system", feature(global_allocator))]
-#![cfg_attr(feature = "alloc_system", feature(allocator_api))]
-
 extern crate capstone_sys;
 
 pub mod arch;


### PR DESCRIPTION
Allocators are enabled on stable in Rust 1.28 and later, so this
now works there.