### PR TITLE
Remove lifetime of Capstone, and adjust self mutablity for disasm

### DIFF
--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -8,7 +8,7 @@ use std::io::Read;
 use std::process;
 
 fn main() {
-    let mut cs = Capstone::new()
+    let cs = Capstone::new()
         .x86()
         .mode(arch::x86::ArchMode::Mode64)
         .build()

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -126,7 +126,7 @@ macro_rules! define_arch_builder {
                         self
                     }
 
-                    fn build<'a>(self) -> CsResult<Capstone<'a>> {
+                    fn build(self) -> CsResult<Capstone> {
                         let mode = match self.mode {
                             Some(mode) => mode,
                             None => {
@@ -288,7 +288,7 @@ pub trait BuildsCapstone<ArchMode> {
     fn detail(self, enable_detail: bool) -> Self;
 
     /// Get final `Capstone`
-    fn build<'a>(self) -> CsResult<Capstone<'a>>;
+    fn build<'a>(self) -> CsResult<Capstone>;
 }
 
 /// Implies that a `CapstoneBuilder` architecture has extra modes

--- a/src/capstone.rs
+++ b/src/capstone.rs
@@ -155,7 +155,7 @@ impl Capstone {
     /// Disassemble all instructions in buffer
     pub fn disasm_all<'a>(
         &'a self,
-        code: &'a [u8],
+        code: &[u8],
         addr: u64,
     ) -> CsResult<Instructions<'a>> {
         self.disasm(code, addr, 0)
@@ -164,7 +164,7 @@ impl Capstone {
     /// Disassemble `count` instructions in `code`
     pub fn disasm_count<'a>(
         &'a self,
-        code: &'a [u8],
+        code: &[u8],
         addr: u64,
         count: usize,
     ) -> CsResult<Instructions<'a>> {
@@ -177,7 +177,7 @@ impl Capstone {
     /// Disassembles a `&[u8]` full of instructions.
     ///
     /// Pass `count = 0` to disassemble all instructions in the buffer.
-    fn disasm<'a>(&'a self, code: &'a [u8], addr: u64, count: usize) -> CsResult<Instructions<'a>> {
+    fn disasm<'a>(&'a self, code: &[u8], addr: u64, count: usize) -> CsResult<Instructions<'a>> {
         let mut ptr: *mut cs_insn = unsafe { mem::zeroed() };
         let insn_count = unsafe {
             cs_disasm(

--- a/src/test.rs
+++ b/src/test.rs
@@ -16,7 +16,7 @@ const IRET: cs_group_type::Type = cs_group_type::CS_GRP_IRET;
 #[test]
 fn test_x86_simple() {
     match Capstone::new().x86().mode(x86::ArchMode::Mode64).build() {
-        Ok(mut cs) => match cs.disasm_all(X86_CODE, 0x1000) {
+        Ok(cs) => match cs.disasm_all(X86_CODE, 0x1000) {
             Ok(insns) => {
                 assert_eq!(insns.len(), 2);
                 let is: Vec<_> = insns.iter().collect();
@@ -60,7 +60,7 @@ fn test_arm_simple() {
 
 #[test]
 fn test_arm64_none() {
-    let mut cs = Capstone::new()
+    let cs = Capstone::new()
         .arm64()
         .mode(arm64::ArchMode::Arm)
         .build()


### PR DESCRIPTION
Discussed in the following post:

https://www.reddit.com/r/rust/comments/9hwr5r/a_rust_ffi_adventure_in_unsafety/

Conclusion:

* There is no need to introduce lifetime for `Capstone` to ensure `Instructions`'s lifetime constrainted.
* The `disasm` methods might not actually need `self` to be mutable, as it only access immutable methods.
* The `disasm` methods uses unbound lifetime, which is not desired here. Bound to `self` instead. However, as the semantic is eager evaluation, there is no need to also bound the code slice.
* Tests fixed to represent that `disasm` is no longer mutating `Capstone`.

This change compiles all tests, but I didn't run the tests, please confirm with your own test before merge. 

