### PR TITLE
don't package PDFs or Xcode projects

### DIFF
--- a/capstone-sys/Cargo.toml
+++ b/capstone-sys/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/capstone-rust/capstone-sys"
 
-exclude = [ "capstone/docs/**", "capstone/xcode/**" ]
+exclude = [ "capstone/docs/**", "capstone/xcode/**", "capstone/msvc/**" ]
 
 [badges]
 travis-ci = { repository = "capstone-rust/capstone-sys" }

--- a/capstone-sys/Cargo.toml
+++ b/capstone-sys/Cargo.toml
@@ -11,6 +11,8 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/capstone-rust/capstone-sys"
 
+exclude = [ "capstone/docs/**", "capstone/xcode/**" ]
+
 [badges]
 travis-ci = { repository = "capstone-rust/capstone-sys" }
 

--- a/capstone-sys/Cargo.toml
+++ b/capstone-sys/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["external-ffi-bindings"]
 links = "capstone"
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/capstone-rust/capstone-sys"
+repository = "https://github.com/capstone-rust/capstone-rs/tree/master/capstone-sys"
 
 exclude = [ "capstone/docs/**", "capstone/xcode/**", "capstone/msvc/**" ]
 


### PR DESCRIPTION
These files aren't used by the crate itself.  For people vendoring the
crate, these files just take up unnecessary space.