### PR TITLE
Support wasm32-wasi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.29.2
+  - 1.36.0
   - stable
   - beta
   - nightly
@@ -27,10 +27,7 @@ matrix:
   # Add each target manually
   include:
     - os: linux
-      rust: 1.29.2
-      env: FEATURES=alloc_system
-    - os: linux
-      rust: stable
+      rust: 1.36.0
     - os: linux
       rust: stable
       env: JOB=valgrind-test
@@ -47,7 +44,7 @@ matrix:
             - valgrind
     - os: linux
       rust: nightly
-      env: JOB=valgrind-test NO_DEFAULT_FEATURES=1
+      env: JOB=valgrind-test
       addons:
         apt:
           packages:
@@ -56,7 +53,6 @@ matrix:
       rust: stable
     - os: osx
       rust: nightly
-      env: NO_DEFAULT_FEATURES=1
     - os: linux
       rust: stable
       env: JOB=cov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - YYYY-MM-DD
 
 ### Added
-- `no_std` compatibility (disable default features)
+- `no_std` compatibility
+
+### Changed
+- Bump minimum Rust version to 1.36.0
 
 ## [0.6.0] - 2019-04-17
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Bindings to the [capstone library][upstream] disassembly framework.
 
 See the [`capstone-sys`](capstone-sys) page for the requirements and supported platforms.
 
-* Minimum Rust Version: `1.29.2` or later
+* Minimum Rust Version: `1.36.0`
 
 # Example
 
@@ -122,11 +122,8 @@ More complex demos welcome!
 
 # Features
 
-- `alloc_system`: use the system allocator instead of the default Rust allocator.
-  Useful for running [Valgrind](http://valgrind.org/).
-  This is already the default behavior in >= 1.32.0.
-- `std`: use the standard library (enabled by default).
-  Set `no-default-features` to use `no_std`.
+- `use_bindgen`: run `bindgen` to generate Rust bindings to Capstone C library
+  instead of using pre-generated bindings (not recommended).
 
 # Reporting Issues
 

--- a/capstone-rs/Cargo.toml
+++ b/capstone-rs/Cargo.toml
@@ -15,7 +15,6 @@ travis-ci = { repository = "capstone-rust/capstone-rs" }
 
 [dependencies]
 capstone-sys = { path = "../capstone-sys", version = "0.10.0" }
-cfg-if = "0.1"
 libc = { version = "0.2", default-features = false }
 
 [dev-dependencies]
@@ -27,8 +26,6 @@ name = "my_benchmark"
 harness = false
 
 [features]
-default = ["std"]
+default = []
 
-alloc_system = []
-std = []
 use_bindgen = ["capstone-sys/use_bindgen"]

--- a/capstone-rs/Cargo.toml
+++ b/capstone-rs/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 name = "capstone"
 repository = "https://github.com/capstone-rust/capstone-rs"
 readme = "README.md"
+edition = "2018"
 version = "0.6.0"
 
 [badges]

--- a/capstone-rs/ci/test.sh
+++ b/capstone-rs/ci/test.sh
@@ -26,6 +26,7 @@ NO_DEFAULT_FEATURES="${NO_DEFAULT_FEATURES:+--no-default-features}"
 PROJECT_NAME="$(grep ^name Cargo.toml | head -n1 | xargs -n1 | tail -n1)"
 TARGET="../target"
 TARGET_COV="${TARGET}/cov"
+export USER="${USER:-$(id -u -n)}"
 
 PASS="PASS"
 FAIL="FAIL"
@@ -36,6 +37,7 @@ else
     EXPECTED_RESULT="$PASS"
 fi
 
+echo "Running as USER=$USER"
 echo "Test should $EXPECTED_RESULT"
 
 Error() {

--- a/capstone-rs/src/arch/arm.rs
+++ b/capstone-rs/src/arch/arm.rs
@@ -1,24 +1,26 @@
 //! Contains arm-specific types
 
-pub use arch::arch_builder::arm::*;
-use arch::DetailsArchInsn;
-use capstone_sys::{arm_op_mem, arm_op_type, cs_arm, cs_arm_op};
-use instruction::{RegId, RegIdInt};
 use core::convert::From;
 use core::{cmp, fmt, slice};
+
+use capstone_sys::{
+    arm_op_mem, arm_op_type, cs_arm, cs_arm_op, arm_shifter,
+    cs_arm_op__bindgen_ty_2};
 use libc::c_uint;
+
+pub use crate::arch::arch_builder::arm::*;
+use crate::arch::DetailsArchInsn;
+use crate::instruction::{RegId, RegIdInt};
 
 pub use capstone_sys::arm_insn_group as ArmInsnGroup;
 pub use capstone_sys::arm_insn as ArmInsn;
 pub use capstone_sys::arm_reg as ArmReg;
-
 pub use capstone_sys::arm_vectordata_type as ArmVectorData;
 pub use capstone_sys::arm_cpsmode_type as ArmCPSMode;
 pub use capstone_sys::arm_cpsflag_type as ArmCPSFlag;
 pub use capstone_sys::arm_cc as ArmCC;
 pub use capstone_sys::arm_mem_barrier as ArmMemBarrier;
 pub use capstone_sys::arm_setend_type as ArmSetendType;
-use capstone_sys::{arm_shifter, cs_arm_op__bindgen_ty_2};
 
 /// Contains ARM-specific details for an instruction
 pub struct ArmInsnDetail<'a>(pub(crate) &'a cs_arm);

--- a/capstone-rs/src/arch/arm64.rs
+++ b/capstone-rs/src/arch/arm64.rs
@@ -1,12 +1,13 @@
 //! Contains arm64-specific types
 
-pub use arch::arch_builder::arm64::*;
-use arch::DetailsArchInsn;
+use libc::c_uint;
+
+pub use crate::arch::arch_builder::arm64::*;
+use crate::arch::DetailsArchInsn;
 use capstone_sys::{arm64_op_mem, arm64_op_type, cs_arm64, cs_arm64_op};
-use instruction::{RegId, RegIdInt};
+use crate::instruction::{RegId, RegIdInt};
 use core::convert::From;
 use core::{cmp, fmt, mem, slice};
-use libc::c_uint;
 
 // Re-exports
 pub use capstone_sys::arm64_insn_group as Arm64InsnGroup;

--- a/capstone-rs/src/arch/evm.rs
+++ b/capstone-rs/src/arch/evm.rs
@@ -1,14 +1,15 @@
 //! Contains EVM-specific types
 
-pub use arch::arch_builder::evm::*;
-use arch::DetailsArchInsn;
-use capstone_sys::cs_evm;
 use core::fmt;
+
+use capstone_sys::cs_evm;
 
 // XXX todo(tmfink): create rusty versions
 pub use capstone_sys::evm_insn_group as EvmInsnGroup;
 pub use capstone_sys::evm_insn as EvmInsn;
-// no register type since EVM has no operands
+
+pub use crate::arch::arch_builder::evm::*;
+use crate::arch::DetailsArchInsn;
 
 /// Contains EVM-specific details for an instruction
 pub struct EvmInsnDetail<'a>(pub(crate) &'a cs_evm);

--- a/capstone-rs/src/arch/m680x.rs
+++ b/capstone-rs/src/arch/m680x.rs
@@ -1,17 +1,20 @@
 //! Contains m680x-specific types
 
-pub use arch::arch_builder::m680x::*;
-use arch::DetailsArchInsn;
+use core::convert::From;
+use core::{fmt, slice};
+
 use capstone_sys::{
     cs_m680x, cs_m680x_op, m680x_op_ext, m680x_op_idx, m680x_op_rel, m680x_op_type,
 };
-use instruction::{RegId, RegIdInt};
-use core::convert::From;
-use core::{fmt, slice};
 
 // XXX todo(tmfink): create rusty versions
 pub use capstone_sys::m680x_insn as M680xInsn;
 pub use capstone_sys::m680x_reg as M680xReg;
+
+pub use crate::arch::arch_builder::m680x::*;
+use crate::arch::DetailsArchInsn;
+use crate::instruction::{RegId, RegIdInt};
+
 
 /// Contains M680X-specific details for an instruction
 pub struct M680xInsnDetail<'a>(pub(crate) &'a cs_m680x);

--- a/capstone-rs/src/arch/m68k.rs
+++ b/capstone-rs/src/arch/m68k.rs
@@ -464,19 +464,11 @@ def_arch_details_struct!(
 #[cfg(test)]
 mod test {
     use super::*;
+    use alloc::vec::Vec;
     use capstone_sys::m68k_address_mode::*;
     use capstone_sys::m68k_op_type::*;
     use capstone_sys::m68k_reg::*;
     use instruction::*;
-
-    cfg_if! {
-        if #[cfg(not(feature = "std"))] {
-            extern crate std;
-
-            use alloc::vec::Vec;
-            use std::prelude::v1::*;
-        }
-    }
 
     const MEM_ZERO: m68k_op_mem = m68k_op_mem {
         base_reg: M68K_REG_INVALID,

--- a/capstone-rs/src/arch/m68k.rs
+++ b/capstone-rs/src/arch/m68k.rs
@@ -3,22 +3,21 @@
 use core::convert::From;
 use core::{cmp, fmt, slice};
 
-pub use arch::arch_builder::m68k::*;
-use arch::DetailsArchInsn;
 use capstone_sys::{
     cs_m68k, cs_m68k_op, cs_m68k_op__bindgen_ty_1, m68k_address_mode, m68k_cpu_size, m68k_fpu_size,
     m68k_op_br_disp, m68k_op_mem, m68k_op_size, m68k_op_type, m68k_reg, m68k_size_type,
 };
-use Error;
-use instruction::{RegId, RegIdInt};
-use prelude::*;
-
-// XXX todo(tmfink): fix racy initialization in Castone C library M68k
 
 // XXX todo(tmfink): create rusty versions
 pub use capstone_sys::m68k_address_mode as M68kAddressMode;
 pub use capstone_sys::m68k_insn as M68kInsn;
 pub use capstone_sys::m68k_reg as M68kReg;
+
+pub use crate::arch::arch_builder::m68k::*;
+use crate::arch::DetailsArchInsn;
+use crate::Error;
+use crate::instruction::{RegId, RegIdInt};
+use crate::prelude::*;
 
 
 /// Contains M68K-specific details for an instruction
@@ -468,7 +467,7 @@ mod test {
     use capstone_sys::m68k_address_mode::*;
     use capstone_sys::m68k_op_type::*;
     use capstone_sys::m68k_reg::*;
-    use instruction::*;
+    use crate::instruction::*;
 
     const MEM_ZERO: m68k_op_mem = m68k_op_mem {
         base_reg: M68K_REG_INVALID,
@@ -600,9 +599,9 @@ mod test {
 
     #[test]
     fn op_eq() {
-        use arch::m68k::M68kOperand::*;
-        use arch::m68k::M68kReg::*;
-        use arch::m68k::*;
+        use crate::arch::m68k::M68kOperand::*;
+        use crate::arch::m68k::M68kReg::*;
+        use crate::arch::m68k::*;
         use capstone_sys::m68k_address_mode::*;
 
         assert_ne!(
@@ -637,7 +636,7 @@ mod test {
 
     #[test]
     fn extra_info() {
-        use arch::DetailsArchInsn;
+        use crate::arch::DetailsArchInsn;
 
         let cs = Capstone::new()
             .m68k()

--- a/capstone-rs/src/arch/mips.rs
+++ b/capstone-rs/src/arch/mips.rs
@@ -3,15 +3,16 @@
 use core::convert::From;
 use core::{cmp, fmt, slice};
 
-pub use arch::arch_builder::mips::*;
-use arch::DetailsArchInsn;
 use capstone_sys::{cs_mips, cs_mips_op, mips_op_mem, mips_op_type};
-use instruction::{RegId, RegIdInt};
 
 // XXX todo(tmfink): create rusty versions
 pub use capstone_sys::mips_insn_group as MipsInsnGroup;
 pub use capstone_sys::mips_insn as MipsInsn;
 pub use capstone_sys::mips_reg as MipsReg;
+
+pub use crate::arch::arch_builder::mips::*;
+use crate::arch::DetailsArchInsn;
+use crate::instruction::{RegId, RegIdInt};
 
 /// Contains MIPS-specific details for an instruction
 pub struct MipsInsnDetail<'a>(pub(crate) &'a cs_mips);

--- a/capstone-rs/src/arch/mod.rs
+++ b/capstone-rs/src/arch/mod.rs
@@ -4,9 +4,9 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 
-use capstone::Capstone;
-use constants::Endian;
-use error::CsResult;
+use crate::capstone::Capstone;
+use crate::constants::Endian;
+use crate::error::CsResult;
 
 macro_rules! define_subset_enum {
     ( [
@@ -87,9 +87,9 @@ macro_rules! define_arch_builder {
             pub mod $arch {
                 use alloc::vec::Vec;
 
-                use capstone::Capstone;
-                use constants::{Arch, Endian, ExtraMode, Mode, Syntax};
-                use error::{CsResult, Error};
+                use crate::capstone::Capstone;
+                use crate::constants::{Arch, Endian, ExtraMode, Mode, Syntax};
+                use crate::error::{CsResult, Error};
 
                 define_arch_builder!( @syntax ( $( $syntax, )* ) );
                 define_arch_builder!( @endian ( $( $endian )* ) );
@@ -643,7 +643,7 @@ macro_rules! def_arch_details_struct {
             }
         }
 
-        impl<'a> ::arch::DetailsArchInsn for $InsnDetail<'a> {
+        impl<'a> crate::arch::DetailsArchInsn for $InsnDetail<'a> {
             type OperandIterator = $OperandIteratorLife;
             type Operand = $Operand;
 

--- a/capstone-rs/src/arch/mod.rs
+++ b/capstone-rs/src/arch/mod.rs
@@ -1,13 +1,12 @@
 //! Contains architecture-specific types and modules
 
-use capstone::Capstone;
-use constants::Endian;
+use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::marker::PhantomData;
-use error::CsResult;
 
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use capstone::Capstone;
+use constants::Endian;
+use error::CsResult;
 
 macro_rules! define_subset_enum {
     ( [
@@ -86,12 +85,11 @@ macro_rules! define_arch_builder {
         $(
             /// Architecture-specific build code
             pub mod $arch {
+                use alloc::vec::Vec;
+
                 use capstone::Capstone;
                 use constants::{Arch, Endian, ExtraMode, Mode, Syntax};
                 use error::{CsResult, Error};
-
-                #[cfg(not(feature = "std"))]
-                use alloc::vec::Vec;
 
                 define_arch_builder!( @syntax ( $( $syntax, )* ) );
                 define_arch_builder!( @endian ( $( $endian )* ) );

--- a/capstone-rs/src/arch/ppc.rs
+++ b/capstone-rs/src/arch/ppc.rs
@@ -3,18 +3,17 @@
 use core::convert::From;
 use core::{cmp, fmt, slice};
 
-pub use arch::arch_builder::ppc::*;
-use arch::DetailsArchInsn;
-use capstone_sys::{cs_ppc, cs_ppc_op, ppc_op_mem, ppc_op_type};
-use instruction::{RegId, RegIdInt};
-
 // XXX todo(tmfink): create rusty versions
 pub use capstone_sys::ppc_insn_group as PpcInsnGroup;
 pub use capstone_sys::ppc_insn as PpcInsn;
 pub use capstone_sys::ppc_reg as PpcReg;
 pub use capstone_sys::ppc_bc as PpcBc;
 pub use capstone_sys::ppc_bh as PpcBh;
-use capstone_sys::ppc_op_crx;
+use capstone_sys::{cs_ppc, cs_ppc_op, ppc_op_mem, ppc_op_crx, ppc_op_type};
+
+pub use crate::arch::arch_builder::ppc::*;
+use crate::arch::DetailsArchInsn;
+use crate::instruction::{RegId, RegIdInt};
 
 /// Contains PPC-specific details for an instruction
 pub struct PpcInsnDetail<'a>(pub(crate) &'a cs_ppc);

--- a/capstone-rs/src/arch/sparc.rs
+++ b/capstone-rs/src/arch/sparc.rs
@@ -1,9 +1,5 @@
 //! Contains sparc-specific types
 
-pub use arch::arch_builder::sparc::*;
-use arch::DetailsArchInsn;
-use capstone_sys::{cs_sparc, cs_sparc_op, sparc_op_mem, sparc_op_type};
-use instruction::{RegId, RegIdInt};
 use core::convert::From;
 use core::{cmp, fmt, slice};
 
@@ -13,6 +9,12 @@ pub use capstone_sys::sparc_insn as SparcInsn;
 pub use capstone_sys::sparc_reg as SparcReg;
 pub use capstone_sys::sparc_cc as SparcCC;
 pub use capstone_sys::sparc_hint as SparcHint;
+use capstone_sys::{cs_sparc, cs_sparc_op, sparc_op_mem, sparc_op_type};
+
+pub use crate::arch::arch_builder::sparc::*;
+use crate::arch::DetailsArchInsn;
+use crate::instruction::{RegId, RegIdInt};
+
 
 /// Contains SPARC-specific details for an instruction
 pub struct SparcInsnDetail<'a>(pub(crate) &'a cs_sparc);

--- a/capstone-rs/src/arch/sysz.rs
+++ b/capstone-rs/src/arch/sysz.rs
@@ -1,3 +1,3 @@
 //! Contains sysz-specific types
 
-pub use arch::arch_builder::sysz::*;
+pub use crate::arch::arch_builder::sysz::*;

--- a/capstone-rs/src/arch/tms320c64x.rs
+++ b/capstone-rs/src/arch/tms320c64x.rs
@@ -1,19 +1,22 @@
 //! Contains tms320c64x-specific types
 
-pub use arch::arch_builder::tms320c64x::*;
+use core::convert::From;
+use core::{cmp, fmt, slice};
+
+use libc::c_int;
 use capstone_sys::{
     cs_tms320c64x, cs_tms320c64x_op, tms320c64x_funit, tms320c64x_mem_dir, tms320c64x_mem_disp,
     tms320c64x_mem_mod, tms320c64x_op_mem, tms320c64x_op_type,
 };
-use instruction::{RegId, RegIdInt};
-use libc::c_int;
-use core::convert::From;
-use core::{cmp, fmt, slice};
 
 // XXX todo(tmfink): create rusty versions
 pub use capstone_sys::tms320c64x_insn as Tms320c64xInsn;
 pub use capstone_sys::tms320c64x_insn_group as Tms320c64xInsnGroup;
 pub use capstone_sys::tms320c64x_reg as Tms320c64xReg;
+
+pub use crate::arch::arch_builder::tms320c64x::*;
+use crate::instruction::{RegId, RegIdInt};
+
 
 /// Contains TMS320C64X-specific details for an instruction
 pub struct Tms320c64xInsnDetail<'a>(pub(crate) &'a cs_tms320c64x);

--- a/capstone-rs/src/arch/x86.rs
+++ b/capstone-rs/src/arch/x86.rs
@@ -1,24 +1,24 @@
 //! Contains x86-specific types
 
-pub use arch::arch_builder::x86::*;
-use arch::DetailsArchInsn;
-use capstone_sys::{x86_op_mem, x86_op_type, cs_x86, cs_x86_op};
-use instruction::{RegId, RegIdInt};
 use core::convert::From;
 use core::{cmp, fmt, slice};
 
+use capstone_sys::{
+    cs_x86_op__bindgen_ty_1, x86_op_mem, x86_op_type, cs_x86, cs_x86_op};
 pub use capstone_sys::x86_insn_group as X86InsnGroup;
 pub use capstone_sys::x86_insn as X86Insn;
 pub use capstone_sys::x86_reg as X86Reg;
 pub use capstone_sys::x86_prefix as X86Prefix;
-
 pub use capstone_sys::x86_avx_bcast as X86AvxBcast;
 pub use capstone_sys::x86_sse_cc as X86SseCC;
 pub use capstone_sys::x86_avx_cc as X86AvxCC;
 pub use capstone_sys::x86_xop_cc as X86XopCC;
 pub use capstone_sys::x86_avx_rm as X86AvxRm;
 
-use capstone_sys::cs_x86_op__bindgen_ty_1;
+pub use crate::arch::arch_builder::x86::*;
+use crate::arch::DetailsArchInsn;
+use crate::instruction::{RegId, RegIdInt};
+
 
 /// Contains X86-specific details for an instruction
 pub struct X86InsnDetail<'a>(pub(crate) &'a cs_x86);

--- a/capstone-rs/src/arch/xcore.rs
+++ b/capstone-rs/src/arch/xcore.rs
@@ -1,9 +1,5 @@
 //! Contains xcore-specific types
 
-pub use arch::arch_builder::xcore::*;
-use arch::DetailsArchInsn;
-use capstone_sys::{cs_xcore, cs_xcore_op, xcore_op_mem, xcore_op_type};
-use instruction::{RegId, RegIdInt};
 use core::convert::From;
 use core::{cmp, fmt, slice};
 
@@ -11,6 +7,11 @@ use core::{cmp, fmt, slice};
 pub use capstone_sys::xcore_insn_group as XcoreInsnGroup;
 pub use capstone_sys::xcore_insn as XcoreInsn;
 pub use capstone_sys::xcore_reg as XcoreReg;
+use capstone_sys::{cs_xcore, cs_xcore_op, xcore_op_mem, xcore_op_type};
+
+pub use crate::arch::arch_builder::xcore::*;
+use crate::arch::DetailsArchInsn;
+use crate::instruction::{RegId, RegIdInt};
 
 /// Contains XCORE-specific details for an instruction
 pub struct XcoreInsnDetail<'a>(pub(crate) &'a cs_xcore);

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -1,20 +1,17 @@
-#[cfg(not(feature = "std"))]
-extern crate alloc;
+use alloc::string::{String, ToString};
+use core::convert::From;
+use core::marker::PhantomData;
+use core::mem;
+use libc::{c_int, c_uint, c_void};
 
 use arch::CapstoneBuilder;
 use capstone_sys::cs_opt_value::*;
 use capstone_sys::*;
 use constants::{Arch, Endian, ExtraMode, Mode, OptValue, Syntax};
-use core::convert::From;
-use core::marker::PhantomData;
-use core::mem;
 use error::*;
 use ffi::str_from_cstr_ptr;
 use instruction::{Insn, InsnDetail, InsnGroupId, InsnId, Instructions, RegId};
-use libc::{c_int, c_uint, c_void};
 
-#[cfg(not(feature = "std"))]
-use alloc::string::{String, ToString};
 
 /// An instance of the capstone disassembler
 #[derive(Debug)]

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -2,15 +2,16 @@ use alloc::string::{String, ToString};
 use core::convert::From;
 use core::marker::PhantomData;
 use core::mem;
+
 use libc::{c_int, c_uint, c_void};
 
-use arch::CapstoneBuilder;
+use crate::arch::CapstoneBuilder;
 use capstone_sys::cs_opt_value::*;
 use capstone_sys::*;
-use constants::{Arch, Endian, ExtraMode, Mode, OptValue, Syntax};
-use error::*;
-use ffi::str_from_cstr_ptr;
-use instruction::{Insn, InsnDetail, InsnGroupId, InsnId, Instructions, RegId};
+use crate::constants::{Arch, Endian, ExtraMode, Mode, OptValue, Syntax};
+use crate::error::*;
+use crate::ffi::str_from_cstr_ptr;
+use crate::instruction::{Insn, InsnDetail, InsnGroupId, InsnId, Instructions, RegId};
 
 
 /// An instance of the capstone disassembler

--- a/capstone-rs/src/ffi.rs
+++ b/capstone-rs/src/ffi.rs
@@ -23,8 +23,8 @@ pub(crate) unsafe fn str_from_cstr_ptr<'a>(ptr: *const c_char) -> Option<&'a str
 
 #[cfg(test)]
 mod test {
-    use core;
     use super::*;
+    use core;
 
     #[test]
     fn cstr_convert() {

--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -3,10 +3,11 @@ use core::marker::PhantomData;
 use core::slice;
 use core::str;
 
-use arch::ArchDetail;
 use capstone_sys::*;
-use constants::Arch;
-use ffi::str_from_cstr_ptr;
+
+use crate::arch::ArchDetail;
+use crate::constants::Arch;
+use crate::ffi::str_from_cstr_ptr;
 
 /// Representation of the array of instructions returned by disasm
 #[derive(Debug)]
@@ -298,8 +299,8 @@ impl<'a> InsnDetail<'a> {
                 $( [ $ARCH:ident, $detail:ident, $insn_detail:ident, $arch:ident ] )*
             ) => {
                 use self::ArchDetail::*;
-                use Arch::*;
-                $( use arch::$arch::$insn_detail; )*
+                use crate::Arch::*;
+                $( use crate::arch::$arch::$insn_detail; )*
 
                 return match self.1 {
                     $(

--- a/capstone-rs/src/lib.rs
+++ b/capstone-rs/src/lib.rs
@@ -134,10 +134,6 @@ extern crate std;
 #[global_allocator]
 static ALLOCATOR: std::alloc::System = std::alloc::System;
 
-
-extern crate capstone_sys;
-extern crate libc;
-
 // Define first so macros are available
 #[macro_use]
 mod constants;
@@ -151,10 +147,10 @@ mod instruction;
 #[cfg(test)]
 mod test;
 
-pub use capstone::*;
-pub use constants::*;
-pub use error::*;
-pub use instruction::*;
+pub use crate::capstone::*;
+pub use crate::constants::*;
+pub use crate::error::*;
+pub use crate::instruction::*;
 
 /// Contains items that you probably want to always import
 ///
@@ -164,11 +160,11 @@ pub use instruction::*;
 /// use capstone::prelude::*;
 /// ```
 pub mod prelude {
-    pub use arch::{
+    pub use crate::arch::{
         self, ArchDetail, BuildsCapstone, BuildsCapstoneEndian, BuildsCapstoneExtraMode,
         BuildsCapstoneSyntax, DetailsArchInsn,
     };
-    pub use {
+    pub use crate::{
         Capstone, CsResult, InsnDetail, InsnGroupId, InsnGroupIdInt, InsnId, InsnIdInt, RegId,
         RegIdInt,
     };

--- a/capstone-rs/src/lib.rs
+++ b/capstone-rs/src/lib.rs
@@ -121,32 +121,19 @@
 //! [upstream]: http://capstone-engine.org/
 //!
 
-#![cfg_attr(not(feature = "std"), feature(alloc), no_std)]
+#![no_std]
 
 #[macro_use]
-extern crate cfg_if;
+extern crate alloc;
 
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        // core crate is auto-imported given no_std
-        extern crate core;
-    } else {
-        #[macro_use] extern crate alloc;
-
-        /// Do nothing for println when no_std
-        #[cfg(test)]
-        macro_rules! println {
-            ( $( $ignore:expr ),* ) => {
-                $({
-                    let _ = $ignore;
-                })*
-            }
-        }
-    }
-}
-
-#[cfg(all(not(feature = "std"), test))]
+#[cfg(test)]
+#[macro_use]
 extern crate std;
+
+#[cfg(test)]
+#[global_allocator]
+static ALLOCATOR: std::alloc::System = std::alloc::System;
+
 
 extern crate capstone_sys;
 extern crate libc;
@@ -168,13 +155,6 @@ pub use capstone::*;
 pub use constants::*;
 pub use error::*;
 pub use instruction::*;
-
-#[cfg(feature = "alloc_system")]
-use std::alloc::System;
-
-#[cfg(feature = "alloc_system")]
-#[global_allocator]
-static ALLOCATOR: System = System;
 
 /// Contains items that you probably want to always import
 ///

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -1,6 +1,5 @@
-use alloc::vec::Vec;
 use alloc::string::String;
-
+use alloc::vec::Vec;
 use std::collections::HashSet;
 
 use capstone_sys::cs_group_type;
@@ -450,8 +449,8 @@ fn instructions_match_detail<T>(
 
 #[test]
 fn test_instruction_details() {
-    use arch::x86::X86Reg;
-    use arch::x86::X86Reg::*;
+    use crate::arch::x86::X86Reg;
+    use crate::arch::x86::X86Reg::*;
 
     let expected_insns: &[(
         &str,
@@ -600,8 +599,8 @@ fn test_arch_mode_endian_insns_detail<T>(
 
 #[test]
 fn test_syntax() {
-    use arch::x86::X86Reg;
-    use arch::x86::X86Reg::*;
+    use crate::arch::x86::X86Reg;
+    use crate::arch::x86::X86Reg::*;
 
     let expected_insns: &[(
         &str,
@@ -880,8 +879,8 @@ fn test_arch_arm() {
 
 #[test]
 fn test_arch_arm_detail() {
-    use arch::arm::ArmOperandType::*;
-    use arch::arm::*;
+    use crate::arch::arm::ArmOperandType::*;
+    use crate::arch::arm::*;
     use capstone_sys::arm_op_mem;
 
     let r0_op = ArmOperand {
@@ -1057,13 +1056,13 @@ fn test_arch_arm64() {
 
 #[test]
 fn test_arch_arm64_detail() {
-    use arch::arm64::Arm64OperandType::*;
-    use arch::arm64::Arm64Pstate::*;
-    use arch::arm64::Arm64Reg::*;
-    use arch::arm64::Arm64Sysreg::*;
-    use arch::arm64::Arm64Vas::*;
-    use arch::arm64::Arm64Vess::*;
-    use arch::arm64::*;
+    use crate::arch::arm64::Arm64OperandType::*;
+    use crate::arch::arm64::Arm64Pstate::*;
+    use crate::arch::arm64::Arm64Reg::*;
+    use crate::arch::arm64::Arm64Sysreg::*;
+    use crate::arch::arm64::Arm64Vas::*;
+    use crate::arch::arm64::Arm64Vess::*;
+    use crate::arch::arm64::*;
     use capstone_sys::arm64_op_mem;
 
     let s0 = Arm64Operand {
@@ -1368,9 +1367,9 @@ fn test_arch_evm_detail() {
 
 #[test]
 fn test_arch_m680x_detail() {
-    use arch::m680x::M680xOperandType::*;
-    use arch::m680x::M680xReg::*;
-    use arch::m680x::*;
+    use crate::arch::m680x::M680xOperandType::*;
+    use crate::arch::m680x::M680xReg::*;
+    use crate::arch::m680x::*;
     use capstone_sys::m680x_op_idx;
 
     let op_idx_zero = m680x_op_idx {
@@ -1762,9 +1761,9 @@ fn test_arch_m680x_detail() {
 
 #[test]
 fn test_arch_m68k_detail() {
-    use arch::m68k::M68kOperand::*;
-    use arch::m68k::M68kReg::*;
-    use arch::m68k::*;
+    use crate::arch::m68k::M68kOperand::*;
+    use crate::arch::m68k::M68kReg::*;
+    use crate::arch::m68k::*;
     use capstone_sys::m68k_address_mode::*;
     use capstone_sys::m68k_op_mem;
 
@@ -2017,8 +2016,8 @@ fn test_arch_mips() {
 
 #[test]
 fn test_arch_mips_detail() {
-    use arch::mips::MipsOperand::*;
-    use arch::mips::*;
+    use crate::arch::mips::MipsOperand::*;
+    use crate::arch::mips::*;
     use capstone_sys::mips_op_mem;
 
     test_arch_mode_endian_insns_detail(
@@ -2105,9 +2104,9 @@ fn test_arch_ppc() {
 
 #[test]
 fn test_arch_ppc_detail() {
-    use arch::ppc::PpcOperand::*;
-    use arch::ppc::PpcReg::*;
-    use arch::ppc::*;
+    use crate::arch::ppc::PpcOperand::*;
+    use crate::arch::ppc::PpcReg::*;
+    use crate::arch::ppc::*;
     use capstone_sys::ppc_op_mem;
 
     test_arch_mode_endian_insns_detail(
@@ -2270,9 +2269,9 @@ fn test_arch_sparc() {
 
 #[test]
 fn test_arch_sparc_detail() {
-    use arch::sparc::SparcOperand::*;
-    use arch::sparc::SparcReg::*;
-    use arch::sparc::*;
+    use crate::arch::sparc::SparcOperand::*;
+    use crate::arch::sparc::SparcReg::*;
+    use crate::arch::sparc::*;
     use capstone_sys::sparc_op_mem;
 
     test_arch_mode_endian_insns_detail(
@@ -2463,9 +2462,9 @@ fn test_arch_systemz() {
 
 #[test]
 fn test_arch_tms320c64x_detail() {
-    use arch::tms320c64x::Tms320c64xOperand::*;
-    use arch::tms320c64x::Tms320c64xReg::*;
-    use arch::tms320c64x::*;
+    use crate::arch::tms320c64x::Tms320c64xOperand::*;
+    use crate::arch::tms320c64x::Tms320c64xReg::*;
+    use crate::arch::tms320c64x::*;
     use capstone_sys::tms320c64x_funit::*;
     use capstone_sys::tms320c64x_mem_dir::*;
     use capstone_sys::tms320c64x_mem_disp::*;
@@ -2670,9 +2669,9 @@ fn test_arch_x86() {
 
 #[test]
 fn test_arch_x86_detail() {
-    use arch::x86::X86OperandType::*;
-    use arch::x86::X86Reg::*;
-    use arch::x86::*;
+    use crate::arch::x86::X86OperandType::*;
+    use crate::arch::x86::X86Reg::*;
+    use crate::arch::x86::*;
     use capstone_sys::*;
 
     // X86 16bit (Intel syntax)
@@ -2926,9 +2925,9 @@ fn test_arch_xcore() {
 // XXX todo(tmfink) investigate upstream xcore operand bugs
 #[test]
 fn test_arch_xcore_detail() {
-    use arch::xcore::XcoreOperand::*;
-    use arch::xcore::XcoreReg::*;
-    use arch::xcore::*;
+    use crate::arch::xcore::XcoreOperand::*;
+    use crate::arch::xcore::XcoreReg::*;
+    use crate::arch::xcore::*;
     use capstone_sys::xcore_op_mem;
 
     test_arch_mode_endian_insns_detail(

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -1,13 +1,5 @@
-cfg_if! {
-    if #[cfg(not(feature = "std"))] {
-        extern crate std;
-
-        use alloc::vec::Vec;
-        use alloc::string::String;
-        use std::prelude::v1::*;
-
-    }
-}
+use alloc::vec::Vec;
+use alloc::string::String;
 
 use std::collections::HashSet;
 

--- a/capstone-sys/Cargo.toml
+++ b/capstone-sys/Cargo.toml
@@ -22,7 +22,7 @@ travis-ci = { repository = "capstone-rust/capstone-sys" }
 
 
 [dependencies]
-libc = { version = "0.2", default-features = false }
+libc = { version = "0.2.59", default-features = false }
 
 [build-dependencies]
 bindgen = { optional = true, version = "0.49.0" }

--- a/cstool/Cargo.toml
+++ b/cstool/Cargo.toml
@@ -3,6 +3,7 @@ name = "cstool"
 version = "0.1.0"
 authors = ["Travis Finkenauer <tmfinken@gmail.com>"]
 license = "MIT"
+edition = "2018"
 
 [dependencies]
 capstone = { path = "../capstone-rs", version = "0.6.0" }

--- a/cstool/LICENSE
+++ b/cstool/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2019 Travis Finkenauer <tmfinken@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/cstool/README.md
+++ b/cstool/README.md
@@ -1,0 +1,108 @@
+# cstool
+
+Disassembles machine code.
+
+
+## Usage
+
+~~~
+cstool [FLAGS] [OPTIONS] --arch <arch> --mode <mode> <--file <file>|--stdin|--code <code>>
+
+FLAGS:
+    -d, --detail     Print details about instructions
+    -h, --help       Prints help information
+    -x, --hex        Treat input has hex; only select characters that are [a-fA-F0-9]
+    -s, --stdin      read binary instructions from stdin
+    -V, --version    Prints version information
+    -v               Sets the level of verbosity
+
+OPTIONS:
+    -r, --addr <address>      address of code
+    -a, --arch <arch>         Architecture [possible values: arm, arm64, mips, x86, ppc, sparc, sysz, xcore, m68k,
+                              tms320c64x, m680x, evm]
+    -c, --code <code>         instruction bytes (implies --hex)
+    -n, --endian <endian>     Endianness [possible values: little, big]
+    -e, --extra <extra>...    Extra Mode [possible values: mclass, v8, micro]
+    -f, --file <file>         input file with binary instructions
+    -m, --mode <mode>         mode [possible values: arm, mode16, mode32, mode64, thumb, mips2, mips3, mips32r6, mips32,
+                              mips64, v9, qpx, m68k000, m68k010, m68k020, m68k030, m68k040, m680x6301, m680x6309,
+                              m680x6800, m680x6801, m680x6805, m680x6808, m680x6809, m680x6811, m680xcpu12, m680xhcs08,
+                              default]
+~~~
+
+## Example
+
+~~~
+# Disassemble 32-bit X86 (non-hex characters are ignored)
+cstool --arch x86 --mode mode32 --code "90 42 e812345678"
+      1000:  90                                  nop
+      1001:  42                                  inc     edx
+      1002:  e8 12 34 56 78                      call    0x78564419
+~~~
+
+## Build
+
+**Requirements:**
+
+- Rust language toolchain (such as from [rustup](https://rustup.rs/))
+- C compiler (such as `clang`, `gcc`, `msvc`)
+
+**Run with cargo:**
+
+~~~
+cargo run -- [arguments]
+~~~
+
+### Build for WASI
+
+[WebAssembly System Interface (WASI)][wasi] provides APIs to run [WebAssembly][wasm] in various contexts, not just the web.
+
+[wasi]: https://github.com/CraneStation/wasmtime/blob/master/docs/WASI-overview.md
+[wasm]: https://webassembly.org/
+
+**Requirements:**
+- `clang-8` (available at https://apt.llvm.org/)
+- WASI sysroot from https://github.com/CraneStation/wasi-libc
+    - Assumed to be installed at `$WASI_SYSROOT`
+- `wasm-wasi` target rust toolchain (tested with Rust 1.36.0):
+    ~~~
+    rustup target add wasm32-wasi
+    ~~~
+- WASI runner to run WASI executable, such as:
+    - [wasmtime](https://github.com/CraneStation/wasmtime)
+    - [wasmer](https://wasmer.io/)
+
+**Build `cstool`:**
+
+Tell `cc` crate to use our WASI sysroot and clang-8 compiler:
+
+~~~sh
+cd cstool  # go to path with cstool dir
+CFLAGS_wasm32_wasi="--sysroot="$WASI_SYSROOT" \
+    CC=clang-8 \
+    cargo +nightly build --target=wasm32-wasi
+~~~
+
+**Run `cstool`:**
+
+~~~
+cd cstool  # go to path with cstool dir
+~~~
+
+Run with `wasmer`:
+
+~~~
+wasmer run ../target/wasm32-wasi/debug/cstool.wasm -- --arch x86 --mode mode32 --code "90 42 e812345678"
+~~~
+
+Run with `wasmtime`:
+~~~
+wasmtime ../target/wasm32-wasi/debug/cstool.wasm -- --arch x86 --mode mode32 --code "90 42 e812345678"
+~~~
+
+Should give output:
+~~~
+      1000:  90                                  nop
+      1001:  42                                  inc     edx
+      1002:  e8 12 34 56 78                      call    0x78564419
+~~~

--- a/cstool/src/bin/cstool.rs
+++ b/cstool/src/bin/cstool.rs
@@ -1,13 +1,5 @@
 //! Disassembles machine code
 
-extern crate capstone;
-extern crate clap;
-
-#[macro_use]
-extern crate log;
-
-extern crate stderrlog;
-
 use std::fmt::Display;
 use std::fs::File;
 use std::io;
@@ -15,9 +7,10 @@ use std::io::prelude::*;
 use std::process::exit;
 use std::str::FromStr;
 
-use capstone::prelude::*;
-use capstone::{Arch, Endian, EnumList, ExtraMode, Mode};
+use capstone::{self, prelude::*, Arch, Endian, EnumList, ExtraMode, Mode};
 use clap::{App, Arg, ArgGroup};
+use log::{debug, info};
+use stderrlog;
 
 const DEFAULT_CAPACITY: usize = 1024;
 

--- a/cstool/src/bin/cstool.rs
+++ b/cstool/src/bin/cstool.rs
@@ -1,25 +1,23 @@
+//! Disassembles machine code
+
 extern crate capstone;
-
 extern crate clap;
-
-#[cfg(feature = "std")]
-#[macro_use]
-extern crate std;
 
 #[macro_use]
 extern crate log;
 
 extern crate stderrlog;
 
-use capstone::prelude::*;
-use capstone::{Arch, Endian, EnumList, ExtraMode, Mode};
-use clap::{App, Arg, ArgGroup};
 use std::fmt::Display;
 use std::fs::File;
 use std::io;
 use std::io::prelude::*;
 use std::process::exit;
 use std::str::FromStr;
+
+use capstone::prelude::*;
+use capstone::{Arch, Endian, EnumList, ExtraMode, Mode};
+use clap::{App, Arg, ArgGroup};
 
 const DEFAULT_CAPACITY: usize = 1024;
 
@@ -137,6 +135,28 @@ fn disasm<T: Iterator<Item = ExtraMode>>(
     }
 }
 
+const FILE_ARG: &str = "file";
+const STDIN_ARG: &str = "stdin";
+const CODE_ARG: &str = "code";
+const ADDRESS_ARG: &str = "address";
+const VERBOSE_ARG: &str = "verbose";
+const HEX_ARG: &str = "hex";
+const DETAIL_ARG: &str = "detail";
+const ARCH_ARG: &str = "arch";
+const MODE_ARG: &str = "mode";
+const EXTRA_MODE_ARG: &str = "extra";
+const ENDIAN_ARG: &str = "endian";
+
+const AFTER_HELP: &str = r#"
+Example:
+
+    # Disassemble 32-bit X86 (non-hex characters are ignored)
+    cstool --arch x86 --mode mode32 --code "90 42 e812345678"
+          1000:  90                                  nop
+          1001:  42                                  inc     edx
+          1002:  e8 12 34 56 78                      call    0x78564419
+"#;
+
 fn main() {
     // Lowercase arches
     let _arches: Vec<String> = Arch::variants()
@@ -161,58 +181,59 @@ fn main() {
 
     let matches = App::new("capstone-rs disassembler tool")
         .about("Disassembles binary file")
+        .after_help(AFTER_HELP)
         .arg(
-            Arg::with_name("file")
+            Arg::with_name(FILE_ARG)
                 .short("f")
-                .long("file")
+                .long(FILE_ARG)
                 .help("input file with binary instructions")
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("stdin")
+            Arg::with_name(STDIN_ARG)
                 .short("s")
-                .long("stdin")
+                .long(STDIN_ARG)
                 .help("read binary instructions from stdin")
                 .takes_value(false),
         )
         .arg(
-            Arg::with_name("code")
+            Arg::with_name(CODE_ARG)
                 .short("c")
-                .long("code")
+                .long(CODE_ARG)
                 .help("instruction bytes (implies --hex)")
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("address")
+            Arg::with_name(ADDRESS_ARG)
                 .short("r")
                 .long("addr")
                 .help("address of code")
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("v")
+            Arg::with_name(VERBOSE_ARG)
                 .short("v")
                 .multiple(true)
                 .help("Sets the level of verbosity"),
         )
         .arg(
-            Arg::with_name("hex")
+            Arg::with_name(HEX_ARG)
                 .short("x")
-                .long("hex")
+                .long(HEX_ARG)
                 .help("Treat input has hex; only select characters that are [a-fA-F0-9]")
                 .takes_value(false),
         )
         .arg(
-            Arg::with_name("DETAIL")
+            Arg::with_name(DETAIL_ARG)
                 .short("d")
-                .long("detail")
+                .long(DETAIL_ARG)
                 .help("Print details about instructions")
                 .takes_value(false),
         )
         .arg(
-            Arg::with_name("ARCH")
+            Arg::with_name(ARCH_ARG)
                 .short("a")
-                .long("arch")
+                .long(ARCH_ARG)
                 .help("Architecture")
                 .takes_value(true)
                 .required(true)
@@ -220,19 +241,19 @@ fn main() {
                 .case_insensitive(true),
         )
         .arg(
-            Arg::with_name("MODE")
+            Arg::with_name(MODE_ARG)
                 .short("m")
-                .long("mode")
-                .help("Mode")
+                .long(MODE_ARG)
+                .help(MODE_ARG)
                 .takes_value(true)
                 .required(true)
                 .possible_values(modes.as_slice())
                 .case_insensitive(true),
         )
         .arg(
-            Arg::with_name("EXTRA_MODE")
+            Arg::with_name(EXTRA_MODE_ARG)
                 .short("e")
-                .long("extra")
+                .long(EXTRA_MODE_ARG)
                 .help("Extra Mode")
                 .takes_value(true)
                 .required(false)
@@ -241,9 +262,9 @@ fn main() {
                 .multiple(true),
         )
         .arg(
-            Arg::with_name("ENDIAN")
+            Arg::with_name(ENDIAN_ARG)
                 .short("n")
-                .long("endian")
+                .long(ENDIAN_ARG)
                 .help("Endianness")
                 .takes_value(true)
                 .required(false)
@@ -251,15 +272,15 @@ fn main() {
                 .case_insensitive(true),
         )
         .group(
-            ArgGroup::with_name("INPUT")
-                .arg("file")
-                .arg("stdin")
-                .arg("code")
+            ArgGroup::with_name("input")
+                .arg(FILE_ARG)
+                .arg(STDIN_ARG)
+                .arg(CODE_ARG)
                 .required(true),
         )
         .get_matches();
 
-    let direct_input_bytes: Vec<u8> = if let Some(file_path) = matches.value_of("file") {
+    let direct_input_bytes: Vec<u8> = if let Some(file_path) = matches.value_of(FILE_ARG) {
         let mut file = File::open(file_path).expect_exit();
         let capacity = match file.metadata() {
             Err(_) => DEFAULT_CAPACITY,
@@ -268,7 +289,7 @@ fn main() {
         let mut buf = Vec::with_capacity(capacity as usize);
         file.read_to_end(&mut buf).expect_exit();
         buf
-    } else if let Some(code) = matches.value_of("code") {
+    } else if let Some(code) = matches.value_of(CODE_ARG) {
         code.as_bytes().iter().map(|x| *x).collect()
     } else {
         let mut buf = Vec::with_capacity(DEFAULT_CAPACITY);
@@ -278,27 +299,27 @@ fn main() {
     };
 
     stderrlog::new()
-        .verbosity(matches.occurrences_of("v") as usize)
+        .verbosity(matches.occurrences_of(VERBOSE_ARG) as usize)
         .init()
         .unwrap();
 
-    let is_hex = matches.is_present("hex") || matches.is_present("code");
+    let is_hex = matches.is_present(HEX_ARG) || matches.is_present(CODE_ARG);
     info!("is_hex = {:?}", is_hex);
 
-    let show_detail = matches.is_present("DETAIL");
+    let show_detail = matches.is_present(DETAIL_ARG);
     info!("show_detail = {:?}", show_detail);
 
-    let arch: Arch = Arch::from_str(matches.value_of("ARCH").unwrap())
+    let arch: Arch = Arch::from_str(matches.value_of(ARCH_ARG).unwrap())
         .unwrap()
         .into();
     info!("Arch = {:?}", arch);
 
-    let mode: Mode = Mode::from_str(matches.value_of("MODE").unwrap())
+    let mode: Mode = Mode::from_str(matches.value_of(MODE_ARG).unwrap())
         .unwrap()
         .into();
     info!("Mode = {:?}", mode);
 
-    let extra_mode: Vec<_> = match matches.values_of("EXTRA_MODE") {
+    let extra_mode: Vec<_> = match matches.values_of(EXTRA_MODE_ARG) {
         None => Vec::with_capacity(0),
         Some(x) => x
             .map(|x| ExtraMode::from(ExtraMode::from_str(x).unwrap()))
@@ -307,12 +328,12 @@ fn main() {
     info!("ExtraMode = {:?}", extra_mode);
 
     let endian: Option<Endian> = matches
-        .value_of("ENDIAN")
+        .value_of(ENDIAN_ARG)
         .map(|x| Endian::from_str(x).expect_exit());
     info!("Endian = {:?}", endian);
 
     let address =
-        u64::from_str_radix(matches.value_of("address").unwrap_or("1000"), 16).expect_exit();
+        u64::from_str_radix(matches.value_of(ADDRESS_ARG).unwrap_or("1000"), 16).expect_exit();
     info!("Address = 0x{:x}", address);
 
     let input_bytes = if is_hex {

--- a/scripts/build_readme.sh
+++ b/scripts/build_readme.sh
@@ -11,14 +11,22 @@ build() {
     dir="$1"; shift
     base="$1"; shift
 
+    INPUT_MD="${dir}/${base}.md"
+    OUTPUT_HTML="${dir}/${base}.html"
+
+    if [ ! -f "$INPUT_MD" ]; then
+        echo "No '$INPUT_MD', skipping"
+        return
+    fi
+
     pandoc \
         -f gfm -t html5 \
         --css scripts/github-md.css -Vpagetitle="${dir}" \
         --standalone \
-        "${dir}/${base}.md" -o "${dir}/${base}.html"
+        "$INPUT_MD" -o "$OUTPUT_HTML"
 }
 
-for dir in capstone-rs capstone-sys; do
+for dir in capstone-rs capstone-sys cstool; do
     build $dir README
     build $dir CHANGELOG
 done


### PR DESCRIPTION
## Requirements
- `clang-8` (available at https://apt.llvm.org/)
- WASI sysroot from https://github.com/CraneStation/wasi-libc
- `wasm-wasi` target for nightly rust toolchain:
    ~~~
    rustup target add --toolchain nightly wasm32-wasi
    ~~~
- wasmer (to run WASI executable): https://wasmer.io/

## Build `cstool`
Tell `cc` crate to use our WASI sysroot and clang-8 compiler:
~~~sh
cd cstool  # go to path with cstool dir
CFLAGS_wasm32_wasi="--sysroot=/path/to/wasi/sysroot" \
    CC=clang-8 \
    cargo +nightly build --target=wasm32-wasi
~~~

## Run `cstool`
~~~
cd cstool  # go to path with cstool dir
wasmer run ../target/wasm32-wasi/debug/cstool.wasm -- --arch x86 --mode mode32 --code 909090e812345678
~~~