### PR TITLE
capstone: add support for cs_ac_type in x86

### DIFF
--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -2693,11 +2693,13 @@ fn test_arch_x86_detail() {
                 &[
                     X86Operand {
                         size: 2,
+                        access: Some(RegAccessType::WriteOnly),
                         op_type: Reg(RegId(X86_REG_CX as RegIdInt)),
                         ..Default::default()
                     },
                     X86Operand {
                         size: 2,
+                        access: Some(RegAccessType::ReadOnly),
                         op_type: Mem(X86OpMem(x86_op_mem {
                             segment: 0,
                             base: X86_REG_SI,
@@ -2716,6 +2718,7 @@ fn test_arch_x86_detail() {
                 &[
                     X86Operand {
                         size: 1,
+                        access: Some(RegAccessType::ReadWrite),
                         op_type: Mem(X86OpMem(x86_op_mem {
                             segment: 0,
                             base: X86_REG_BX,
@@ -2727,6 +2730,7 @@ fn test_arch_x86_detail() {
                     },
                     X86Operand {
                         size: 1,
+                        access: Some(RegAccessType::ReadOnly),
                         op_type: Reg(RegId(X86_REG_AL as RegIdInt)),
                         ..Default::default()
                     },
@@ -2738,6 +2742,7 @@ fn test_arch_x86_detail() {
                 b"\xd8\x81\xc6\x34",
                 &[X86Operand {
                     size: 4,
+                    access: Some(RegAccessType::ReadOnly),
                     op_type: Mem(X86OpMem(x86_op_mem {
                         segment: 0,
                         base: X86_REG_BX,
@@ -2755,11 +2760,13 @@ fn test_arch_x86_detail() {
                 &[
                     X86Operand {
                         size: 1,
+                        access: Some(RegAccessType::ReadWrite),
                         op_type: Reg(RegId(X86_REG_AL as RegIdInt)),
                         ..Default::default()
                     },
                     X86Operand {
                         size: 1,
+                        access: Some(RegAccessType::ReadOnly),
                         op_type: Mem(X86OpMem(x86_op_mem {
                             segment: 0,
                             base: X86_REG_BX,
@@ -2793,11 +2800,13 @@ fn test_arch_x86_detail() {
                 &[
                     X86Operand {
                         size: 4,
+                        access: Some(RegAccessType::WriteOnly),
                         op_type: Reg(RegId(X86_REG_ECX as RegIdInt)),
                         ..Default::default()
                     },
                     X86Operand {
                         size: 4,
+                        access: Some(RegAccessType::ReadOnly),
                         op_type: Mem(X86OpMem(x86_op_mem {
                             segment: 0,
                             base: X86_REG_EDX,
@@ -2816,11 +2825,13 @@ fn test_arch_x86_detail() {
                 &[
                     X86Operand {
                         size: 4,
+                        access: Some(RegAccessType::ReadWrite),
                         op_type: Reg(RegId(X86_REG_EAX as RegIdInt)),
                         ..Default::default()
                     },
                     X86Operand {
                         size: 4,
+                        access: Some(RegAccessType::ReadOnly),
                         op_type: Reg(RegId(X86_REG_EBX as RegIdInt)),
                         ..Default::default()
                     },
@@ -2833,11 +2844,13 @@ fn test_arch_x86_detail() {
                 &[
                     X86Operand {
                         size: 4,
+                        access: Some(RegAccessType::ReadWrite),
                         op_type: Reg(RegId(X86_REG_ESI as RegIdInt)),
                         ..Default::default()
                     },
                     X86Operand {
                         size: 4,
+                        access: None,
                         op_type: Imm(0x1234),
                         ..Default::default()
                     },
@@ -2864,6 +2877,7 @@ fn test_arch_x86_detail() {
                 b"\x55",
                 &[X86Operand {
                     size: 8,
+                    access: Some(RegAccessType::ReadOnly),
                     op_type: Reg(RegId(X86_REG_RBP as RegIdInt)),
                     ..Default::default()
                 }],
@@ -2875,11 +2889,13 @@ fn test_arch_x86_detail() {
                 &[
                     X86Operand {
                         size: 8,
+                        access: Some(RegAccessType::WriteOnly),
                         op_type: Reg(RegId(X86_REG_RAX as RegIdInt)),
                         ..Default::default()
                     },
                     X86Operand {
                         size: 8,
+                        access: Some(RegAccessType::ReadOnly),
                         op_type: Mem(X86OpMem(x86_op_mem {
                             segment: 0,
                             base: X86_REG_RIP,

--- a/capstone-sys/build.rs
+++ b/capstone-sys/build.rs
@@ -172,7 +172,7 @@ fn write_bindgen_bindings(
         .layout_tests(false) // eliminate test failures on platforms with different pointer sizes
         .impl_debug(true)
         .constified_enum_module("cs_err|cs_group_type|cs_opt_value")
-        .bitfield_enum("cs_mode")
+        .bitfield_enum("cs_mode|cs_ac_type")
         .rustified_enum(".*");
 
     // Whitelist cs_.* functions and types

--- a/capstone-sys/pre_generated/capstone.rs
+++ b/capstone-sys/pre_generated/capstone.rs
@@ -243,18 +243,43 @@ pub enum cs_op_type {
     #[doc = "< Floating-Point operand."]
     CS_OP_FP = 4,
 }
-#[repr(u32)]
+#[doc = "< Uninitialized/invalid access type."]
+pub const CS_AC_INVALID: cs_ac_type = cs_ac_type(0);
+#[doc = "< Operand read from memory or register."]
+pub const CS_AC_READ: cs_ac_type = cs_ac_type(1);
+#[doc = "< Operand write to memory or register."]
+pub const CS_AC_WRITE: cs_ac_type = cs_ac_type(2);
+impl ::core::ops::BitOr<cs_ac_type> for cs_ac_type {
+    type Output = Self;
+    #[inline]
+    fn bitor(self, other: Self) -> Self {
+        cs_ac_type(self.0 | other.0)
+    }
+}
+impl ::core::ops::BitOrAssign for cs_ac_type {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: cs_ac_type) {
+        self.0 |= rhs.0;
+    }
+}
+impl ::core::ops::BitAnd<cs_ac_type> for cs_ac_type {
+    type Output = Self;
+    #[inline]
+    fn bitand(self, other: Self) -> Self {
+        cs_ac_type(self.0 & other.0)
+    }
+}
+impl ::core::ops::BitAndAssign for cs_ac_type {
+    #[inline]
+    fn bitand_assign(&mut self, rhs: cs_ac_type) {
+        self.0 &= rhs.0;
+    }
+}
+#[repr(C)]
 #[doc = " Common instruction operand access types - to be consistent across all architectures."]
 #[doc = " It is possible to combine access types, for example: CS_AC_READ | CS_AC_WRITE"]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum cs_ac_type {
-    #[doc = "< Uninitialized/invalid access type."]
-    CS_AC_INVALID = 0,
-    #[doc = "< Operand read from memory or register."]
-    CS_AC_READ = 1,
-    #[doc = "< Operand write to memory or register."]
-    CS_AC_WRITE = 2,
-}
+pub struct cs_ac_type(pub u32);
 pub mod cs_group_type {
     #[doc = " Common instruction groups - to be consistent across all architectures."]
     pub type Type = u32;


### PR DESCRIPTION
I don't think that generating `cs_ac_type` as an enum is a good option — it's a bitflag in fact. I had to write a ton of if-else as a workaround. Suggestions are appreciated!