### PR TITLE
capstone: add cs_regs_access

### DIFF
--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -388,15 +388,7 @@ impl Capstone {
     /// 2. Skipdata is disabled
     /// 3. Capstone was not compiled in diet mode
     pub fn insn_regs_access<'s, 'i: 's>(&'s self, insn: &'i Insn) -> CsResult<InsnRegsAccess> {
-        if !self.detail_enabled {
-            Err(Error::DetailOff)
-        } else if insn.id().0 == 0 {
-            Err(Error::IrrelevantDataInSkipData)
-        } else if Self::is_diet() {
-            Err(Error::IrrelevantDataInDiet)
-        } else {
-            Ok(unsafe { insn.regs_access(self.csh()) })
-        }
+        insn.regs_access(self.csh())
     }
 
     /// Returns a tuple (major, minor) indicating the version of the capstone C library.

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -11,7 +11,9 @@ use capstone_sys::*;
 use crate::constants::{Arch, Endian, ExtraMode, Mode, OptValue, Syntax};
 use crate::error::*;
 use crate::ffi::str_from_cstr_ptr;
-use crate::instruction::{Insn, InsnDetail, InsnGroupId, InsnId, Instructions, RegId};
+use crate::instruction::{
+    Insn, InsnDetail, InsnGroupId, InsnId, InsnRegsAccess, Instructions, RegId,
+};
 
 
 /// An instance of the capstone disassembler
@@ -375,6 +377,25 @@ impl Capstone {
             Err(Error::IrrelevantDataInDiet)
         } else {
             Ok(unsafe { insn.detail(self.arch) })
+        }
+    }
+
+    /// Returns `RegsAccess` structure for a given instruction
+    ///
+    /// Requires:
+    ///
+    /// 1. Instruction was created with detail enabled
+    /// 2. Skipdata is disabled
+    /// 3. Capstone was not compiled in diet mode
+    pub fn insn_regs_access<'s, 'i: 's>(&'s self, insn: &'i Insn) -> CsResult<InsnRegsAccess> {
+        if !self.detail_enabled && false {
+            Err(Error::DetailOff)
+        } else if insn.id().0 == 0 {
+            Err(Error::IrrelevantDataInSkipData)
+        } else if Self::is_diet() {
+            Err(Error::IrrelevantDataInDiet)
+        } else {
+            Ok(unsafe { insn.regs_access(self.csh()) })
         }
     }
 

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -388,7 +388,7 @@ impl Capstone {
     /// 2. Skipdata is disabled
     /// 3. Capstone was not compiled in diet mode
     pub fn insn_regs_access<'s, 'i: 's>(&'s self, insn: &'i Insn) -> CsResult<InsnRegsAccess> {
-        if !self.detail_enabled && false {
+        if !self.detail_enabled {
             Err(Error::DetailOff)
         } else if insn.id().0 == 0 {
             Err(Error::IrrelevantDataInSkipData)

--- a/capstone-rs/src/lib.rs
+++ b/capstone-rs/src/lib.rs
@@ -165,7 +165,7 @@ pub mod prelude {
         BuildsCapstoneSyntax, DetailsArchInsn,
     };
     pub use crate::{
-        Capstone, CsResult, InsnDetail, InsnGroupId, InsnGroupIdInt, InsnId, InsnIdInt, RegId,
-        RegIdInt,
+        Capstone, CsResult, InsnDetail, InsnGroupId, InsnGroupIdInt, InsnId, InsnIdInt,
+        InsnRegsAccess, RegId, RegIdInt,
     };
 }

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -560,7 +560,10 @@ fn test_instruction_register_access() {
         let insn = insns.iter().next().unwrap();
         let access = cs.insn_regs_access(&insn).unwrap();
 
+        assert_eq!(regs_read.len(), access.regs_read_count() as usize, "regs_read_count did not match");
         assert_regs_match!(regs_read, access.regs_read(), "read_regs did not match");
+
+        assert_eq!(regs_write.len(), access.regs_write_count() as usize, "regs_write_count did not match");
         assert_regs_match!(regs_write, access.regs_write(), "regs_write did not match");
     }
 }

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -127,8 +127,14 @@ fn test_detail_false_fail() {
 
     assert_eq!(cs.insn_detail(&insns[0]).unwrap_err(), Error::DetailOff);
     assert_eq!(cs.insn_detail(&insns[1]).unwrap_err(), Error::DetailOff);
-    assert_eq!(cs.insn_regs_access(&insns[0]).unwrap_err(), Error::DetailOff);
-    assert_eq!(cs.insn_regs_access(&insns[1]).unwrap_err(), Error::DetailOff);
+    assert_eq!(
+        cs.insn_regs_access(&insns[0]).unwrap_err(),
+        Error::DetailOff
+    );
+    assert_eq!(
+        cs.insn_regs_access(&insns[1]).unwrap_err(),
+        Error::DetailOff
+    );
 }
 
 #[test]
@@ -502,13 +508,29 @@ fn test_instruction_register_access() {
 
     let expected: &[(&[u8], &[_], &[_])] = &[
         // add rax, rax
-        (b"\x48\x01\xc0", &[X86_REG_RAX], &[X86_REG_EFLAGS, X86_REG_RAX]),
+        (
+            b"\x48\x01\xc0",
+            &[X86_REG_RAX],
+            &[X86_REG_EFLAGS, X86_REG_RAX],
+        ),
         // mov rax, 0x1234567812345678
-        (b"\x48\xb8\x78\x56\x34\x12\x78\x56\x34\x12", &[], &[X86_REG_RAX]),
+        (
+            b"\x48\xb8\x78\x56\x34\x12\x78\x56\x34\x12",
+            &[],
+            &[X86_REG_RAX],
+        ),
         // mov DWORD PTR [rbp+rbx*8-0x4], eax
-        (b"\x89\x44\xdd\xfc", &[X86_REG_RBP, X86_REG_RBX, X86_REG_EAX], &[]),
+        (
+            b"\x89\x44\xdd\xfc",
+            &[X86_REG_RBP, X86_REG_RBX, X86_REG_EAX],
+            &[],
+        ),
         // mov rax, QWORD PTR [rbp+rbx*8-0x4]
-        (b"\x48\x8b\x44\xdd\xfc", &[X86_REG_RBP, X86_REG_RBX], &[X86_REG_RAX]),
+        (
+            b"\x48\x8b\x44\xdd\xfc",
+            &[X86_REG_RBP, X86_REG_RBX],
+            &[X86_REG_RAX],
+        ),
     ];
 
     let cs = Capstone::new()
@@ -523,7 +545,11 @@ fn test_instruction_register_access() {
             assert_eq!($expected.len(), $actual_regs.len(), $msg);
 
             for (expected, actual) in $expected.iter().zip($actual_regs) {
-                println!("expected = {:?}, actual = {:?}", cs.reg_name(RegId(*expected as u16)), cs.reg_name(actual));
+                println!(
+                    "expected = {:?}, actual = {:?}",
+                    cs.reg_name(RegId(*expected as u16)),
+                    cs.reg_name(actual)
+                );
                 assert_eq!(*expected, actual.0 as u32, $msg);
             }
         }};

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -127,6 +127,8 @@ fn test_detail_false_fail() {
 
     assert_eq!(cs.insn_detail(&insns[0]).unwrap_err(), Error::DetailOff);
     assert_eq!(cs.insn_detail(&insns[1]).unwrap_err(), Error::DetailOff);
+    assert_eq!(cs.insn_regs_access(&insns[0]).unwrap_err(), Error::DetailOff);
+    assert_eq!(cs.insn_regs_access(&insns[1]).unwrap_err(), Error::DetailOff);
 }
 
 #[test]


### PR DESCRIPTION
Adds support for `cs_regs_access`, fixes #63.

I'm not sure how to implement the tests yet, the `instructions_*` tests are a bit complicated on first sight.