### PR TITLE
Update bindgen

### DIFF
--- a/capstone-sys/Cargo.toml
+++ b/capstone-sys/Cargo.toml
@@ -25,7 +25,7 @@ travis-ci = { repository = "capstone-rust/capstone-sys" }
 libc = { version = "0.2.59", default-features = false }
 
 [build-dependencies]
-bindgen = { optional = true, version = "0.49.0" }
+bindgen = { optional = true, version = "0.52.0" }
 cc = "1.0"
 
 [features]


### PR DESCRIPTION
capstone-sys doesn't build with the bindgen feature on latest stable (rust 1.39):

```
$ cargo build --features use_bindgen
[...]
    Compiling capstone-sys v0.10.0 (/home/user/src/capstone-rs/capstone-sys)
error[E0277]: arrays only have std trait implementations for lengths 0..=32
   --> /home/user/src/capstone-rs/target/debug/build/capstone-sys-46af2af488fb2973/out/capstone.rs:885:5
    |
885 |     pub operands: [cs_arm_op; 36usize],
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `core::array::LengthAtMost32` is not implemented for `[cs_arm_op; 36]`
    |
    = note: required because of the requirements on the impl of `core::fmt::Debug` for `[cs_arm_op; 36]`
    = note: required because of the requirements on the impl of `core::fmt::Debug` for `&[cs_arm_op; 36]`
    = note: required for the cast to the object type `dyn core::fmt::Debug`

error[E0277]: arrays only have std trait implementations for lengths 0..=32
     --> /home/user/src/capstone-rs/target/debug/build/capstone-sys-46af2af488fb2973/out/capstone.rs:10809:5
      |
10809 |     pub op_str: [libc::c_char; 160usize],
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `core::array::LengthAtMost32` is not implemented for `[i8; 160]`
      |
      = note: required because of the requirements on the impl of `core::fmt::Debug` for `[i8; 160]`
      = note: required because of the requirements on the impl of `core::fmt::Debug` for `&[i8; 160]`
      = note: required for the cast to the object type `dyn core::fmt::Debug`
```

It seems to be a bindgen issue (https://github.com/rust-lang/rust/issues/65522), upgrading to the latest version (0.52.0) fixes it.