### PR TITLE
Allow Instructions to deref to slice of Insn

### DIFF
--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -118,7 +118,8 @@ impl<'a> core::ops::Deref for Instructions<'a> {
     type Target = [Insn<'a>];
 
     fn deref(&self) -> &[Insn<'a>] {
-        unsafe { core::slice::from_raw_parts(self.0.as_ptr() as *const Insn, self.0.len()) }
+        // SAFETY: `cs_insn` has the same memory layout as `Insn`
+        unsafe { &*(self.0 as *const [cs_insn] as *const [Insn]) }
     }
 }
 

--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -114,6 +114,14 @@ impl<'a> Instructions<'a> {
     }
 }
 
+impl<'a> core::ops::Deref for Instructions<'a> {
+    type Target = [Insn<'a>];
+
+    fn deref(&self) -> &[Insn<'a>] {
+        unsafe { core::slice::from_raw_parts(self.0.as_ptr() as *const Insn, self.0.len()) }
+    }
+}
+
 impl<'a> Drop for Instructions<'a> {
     fn drop(&mut self) {
         if !self.is_empty() {
@@ -184,6 +192,7 @@ impl_SliceIterator_wrapper!(
 );
 
 /// A wrapper for the raw capstone-sys instruction
+#[repr(transparent)]
 pub struct Insn<'a> {
     /// Inner `cs_insn`
     pub(crate) insn: cs_insn,


### PR DESCRIPTION
Makes Insn transparent so that cs_insn can be safely converted to it.
This makes it possible to just make Instructions deref to a slice of
Insn so that is can be passed around more easily without an extra
layer of indirection on top of the slice.

This is a small quality of life improvement that allows things like this:

```rust
pub fn use_instrs<'i>(insn: &[Insn<'i>]) {
    // use as a slice
}

pub fn create_instrs() {
    let cs = Capstone::new()
        .x86()
        .mode(arch::x86::ArchMode::Mode64)
        .syntax(arch::x86::ArchSyntax::Intel)
        .detail(true)
        .build().unwrap();
    let insn = cs
        .disasm_all(symbol_code, test_symbol.addr).unwrap();

    // Deref will coerce to &[Insn<'i>] here
    use_instrs(&insn);
}

```