### PR TITLE
Fix failing Cirrus CI FreeBSD tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,13 @@ test_task:
 
   install_rust_script:
     - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $CHANNEL
+
   install_packages_script:
+    # Work around https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=244549
+    - pkg update -f
+    - pkg clean
+
     - pkg install -y bash
+
   test_script:
     - bash -c 'source ~/.cargo/env; cargo -V; ./capstone-rs/ci/test.sh'

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ test_task:
 
   install_packages_script:
     # Work around https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=244549
-    - pkg bootstrap -f
+    - ASSUME_ALWAYS_YES=yes pkg bootstrap -f
 
     - pkg install -y bash
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,8 +13,7 @@ test_task:
 
   install_packages_script:
     # Work around https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=244549
-    - pkg update -f
-    - pkg clean
+    - pkg bootstrap -f
 
     - pkg install -y bash
 


### PR DESCRIPTION
Pkg install was failing:

~~~
pkg install -y bash
Updating FreeBSD repository catalogue...
Fetching meta.txz: . done
pkg: repository meta /var/db/pkg/FreeBSD.meta has wrong version 2
repository FreeBSD has no meta file, using default settings
Fetching packagesite.txz: .......... done
pkg: repository meta /var/db/pkg/FreeBSD.meta has wrong version 2
pkg: Repository FreeBSD load error: meta cannot be loaded No error: 0
Unable to open created repository FreeBSD
Unable to update repository FreeBSD
Error updating repositories!
Exit status: 3
~~~

Example Cirrus CI failure: https://cirrus-ci.com/task/5812812263981056

FreeBSD Bugzilla Bug 244549:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=244549