### PR TITLE
Cleanup instruction iterator

### DIFF
--- a/capstone-rs/examples/demo.rs
+++ b/capstone-rs/examples/demo.rs
@@ -8,12 +8,8 @@ const MIPS_CODE: &'static [u8] = b"\x56\x34\x21\x34\xc2\x17\x01\x00";
 const X86_CODE: &'static [u8] = b"\x55\x48\x8b\x05\xb8\x13\x00\x00\xe9\x14\x9e\x08\x00\x45\x31\xe4";
 
 /// Print register names
-fn reg_names<T, I>(cs: &Capstone, regs: T) -> String
-where
-    T: Iterator<Item = I>,
-    I: Into<RegId>,
-{
-    let names: Vec<String> = regs.map(|x| cs.reg_name(x.into()).unwrap()).collect();
+fn reg_names(cs: &Capstone, regs: &[RegId]) -> String {
+    let names: Vec<String> = regs.iter().map(|&x| cs.reg_name(x).unwrap()).collect();
     names.join(", ")
 }
 

--- a/capstone-rs/src/arch/m68k.rs
+++ b/capstone-rs/src/arch/m68k.rs
@@ -659,7 +659,7 @@ mod test {
         let mut insns_iter = insns.iter();
 
         // jsr
-        let insn_jsr: Insn = insns_iter.next().unwrap();
+        let insn_jsr: &Insn = insns_iter.next().unwrap();
         let detail = cs.insn_detail(&insn_jsr).unwrap();
         let _arch_detail = detail.arch_detail();
         let arch_detail = _arch_detail.m68k().unwrap();

--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -103,12 +103,6 @@ impl<'a> Instructions<'a> {
         self.0.len()
     }
 
-    /// Iterator over instructions
-    pub fn iter(&'a self) -> InstructionIterator<'a> {
-        let iter = self.0.iter();
-        InstructionIterator(iter)
-    }
-
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -177,20 +171,6 @@ macro_rules! impl_SliceIterator_wrapper {
         }
     }
 }
-
-/// An iterator over the instructions returned by disasm
-///
-/// This is currently the only supported interface for reading them.
-pub struct InstructionIterator<'a>(slice::Iter<'a, cs_insn>);
-
-impl_SliceIterator_wrapper!(
-    impl<'a> Iterator for InstructionIterator<'a> {
-        type Item = Insn<'a>;
-        [
-            |x| Insn { insn: *x, _marker: PhantomData }
-        ]
-    }
-);
 
 /// A wrapper for the raw capstone-sys instruction
 #[repr(transparent)]

--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -38,6 +38,16 @@ pub type RegIdInt = u16;
 #[repr(transparent)]
 pub struct RegId(pub RegIdInt);
 
+impl core::convert::From<u32> for RegId {
+    fn from(v: u32) -> RegId {
+        if v <= core::u16::MAX as u32 {
+            RegId(v as u16)
+        } else {
+            RegId(0)
+        }
+    }
+}
+
 /// Represents how the register is accessed.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum RegAccessType {

--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -173,6 +173,7 @@ macro_rules! impl_SliceIterator_wrapper {
 }
 
 /// A wrapper for the raw capstone-sys instruction
+#[derive(Clone)]
 #[repr(transparent)]
 pub struct Insn<'a> {
     /// Inner `cs_insn`

--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -35,6 +35,7 @@ pub type RegIdInt = u16;
 
 /// Represents an register id, which is architecture-specific.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
 pub struct RegId(pub RegIdInt);
 
 /// Represents how the register is accessed.
@@ -255,42 +256,6 @@ impl<'a> Display for Insn<'a> {
     }
 }
 
-/// Iterator over registers ids
-#[derive(Debug, Clone)]
-pub struct RegsIter<'a, T: 'a + Into<RegIdInt> + Copy>(slice::Iter<'a, T>);
-
-impl<'a, T: 'a + Into<RegIdInt> + Copy> Iterator for RegsIter<'a, T> {
-    type Item = RegId;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|x| RegId((*x).into()))
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.0.size_hint()
-    }
-
-    #[inline]
-    fn count(self) -> usize {
-        self.0.count()
-    }
-}
-
-impl<'a, T: 'a + Into<RegIdInt> + Copy> ExactSizeIterator for RegsIter<'a, T> {
-    #[inline]
-    fn len(&self) -> usize {
-        self.0.len()
-    }
-}
-
-impl<'a, T: 'a + Into<RegIdInt> + Copy> DoubleEndedIterator for RegsIter<'a, T> {
-    #[inline]
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.0.next_back().map(|x| RegId((*x).into()))
-    }
-}
-
 /// Iterator over instruction group ids
 #[derive(Debug, Clone)]
 pub struct InsnGroupIter<'a>(slice::Iter<'a, InsnGroupIdInt>);
@@ -307,23 +272,19 @@ impl_SliceIterator_wrapper!(
 
 impl<'a> InsnDetail<'a> {
     /// Returns the implicit read registers
-    pub fn regs_read(&self) -> RegsIter<RegIdInt> {
-        RegsIter((*self.0).regs_read[..self.regs_read_count() as usize].iter())
-    }
-
-    /// Returns the number of implicit read registers
-    pub fn regs_read_count(&self) -> u8 {
-        (*self.0).regs_read_count
+    pub fn regs_read(&self) -> &[RegId] {
+        unsafe {
+            &*(&self.0.regs_read[..self.0.regs_read_count as usize] as *const [RegIdInt]
+                as *const [RegId])
+        }
     }
 
     /// Returns the implicit write registers
-    pub fn regs_write(&self) -> RegsIter<RegIdInt> {
-        RegsIter((*self.0).regs_write[..self.regs_write_count() as usize].iter())
-    }
-
-    /// Returns the number of implicit write registers
-    pub fn regs_write_count(&self) -> u8 {
-        (*self.0).regs_write_count
+    pub fn regs_write(&self) -> &[RegId] {
+        unsafe {
+            &*(&self.0.regs_write[..self.0.regs_write_count as usize] as *const [RegIdInt]
+                as *const [RegId])
+        }
     }
 
     /// Returns the groups to which this instruction belongs
@@ -376,9 +337,7 @@ impl<'a> Debug for InsnDetail<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         fmt.debug_struct("Detail")
             .field("regs_read", &self.regs_read())
-            .field("regs_read_count", &self.regs_read_count())
             .field("regs_write", &self.regs_write())
-            .field("regs_write_count", &self.regs_write_count())
             .field("groups", &self.groups())
             .field("groups_count", &self.groups_count())
             .finish()

--- a/capstone-rs/src/lib.rs
+++ b/capstone-rs/src/lib.rs
@@ -14,12 +14,8 @@
 //! const X86_CODE: &'static [u8] = b"\x55\x48\x8b\x05\xb8\x13\x00\x00\xe9\x14\x9e\x08\x00\x45\x31\xe4";
 //!
 //! /// Print register names
-//! fn reg_names<T, I>(cs: &Capstone, regs: T) -> String
-//! where
-//!     T: Iterator<Item = I>,
-//!     I: Into<RegId>,
-//! {
-//!     let names: Vec<String> = regs.map(|x| cs.reg_name(x.into()).unwrap()).collect();
+//! fn reg_names(cs: &Capstone, regs: &[RegId]) -> String {
+//!     let names: Vec<String> = regs.iter().map(|&x| cs.reg_name(x).unwrap()).collect();
 //!     names.join(", ")
 //! }
 //!

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -256,7 +256,7 @@ fn test_instruction_detail_helper<T>(
 
 /// Assert instruction belongs or does not belong to groups, testing both insn_belongs_to_group
 /// and insn_group_ids
-fn test_instruction_group_helper<R: Into<u32>>(
+fn test_instruction_group_helper<R: Copy + Into<RegId>>(
     cs: &Capstone,
     insn: &Insn,
     mnemonic_name: &str,
@@ -265,9 +265,7 @@ fn test_instruction_group_helper<R: Into<u32>>(
     expected_regs_read: &[R],
     expected_regs_write: &[R],
     has_default_syntax: bool,
-) where
-    R: Into<u32> + Copy,
-{
+) {
     test_instruction_helper(&cs, insn, mnemonic_name, bytes, has_default_syntax);
     let detail = cs.insn_detail(insn).expect("Unable to get detail");
 
@@ -298,12 +296,9 @@ fn test_instruction_group_helper<R: Into<u32>>(
 
     macro_rules! assert_regs_match {
         ($expected:expr, $actual_regs:expr, $msg:expr) => {{
-            let mut expected_regs: Vec<_> = $expected
-                .iter()
-                .map(|x| RegId(x.clone().into() as RegIdInt))
-                .collect();
+            let mut expected_regs: Vec<RegId> = $expected.iter().map(|&x| x.into()).collect();
             expected_regs.sort_unstable();
-            let mut regs: Vec<_> = $actual_regs.collect();
+            let mut regs: Vec<RegId> = $actual_regs.iter().map(|&x| x.into()).collect();
             regs.sort_unstable();
             assert_eq!(expected_regs, regs, $msg);
         }};
@@ -321,13 +316,11 @@ fn test_instruction_group_helper<R: Into<u32>>(
     );
 }
 
-fn instructions_match_group<R>(
+fn instructions_match_group<R: Copy + Into<RegId>>(
     cs: &mut Capstone,
     expected_insns: &[(&str, &[u8], &[cs_group_type::Type], &[R], &[R])],
     has_default_syntax: bool,
-) where
-    R: Into<u32> + Copy,
-{
+) {
     let insns_buf: Vec<u8> = expected_insns
         .iter()
         .flat_map(|&(_, bytes, _, _, _)| bytes)

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -340,7 +340,7 @@ fn instructions_match_group<R>(
     let insns = cs
         .disasm_all(&insns_buf, START_TEST_ADDR)
         .expect("Failed to disassemble");
-    let insns: Vec<Insn> = insns.iter().collect();
+    let insns: Vec<&Insn> = insns.iter().collect();
 
     // Check number of instructions
     assert_eq!(insns.len(), expected_insns.len());

--- a/cstool/src/bin/cstool.rs
+++ b/cstool/src/bin/cstool.rs
@@ -34,12 +34,8 @@ where
 }
 
 /// Print register names
-fn reg_names<T, I>(cs: &Capstone, regs: T) -> String
-where
-    T: Iterator<Item = I>,
-    I: Into<RegId>,
-{
-    let names: Vec<String> = regs.map(|x| cs.reg_name(x.into()).unwrap()).collect();
+fn reg_names(cs: &Capstone, regs: &[RegId]) -> String {
+    let names: Vec<String> = regs.iter().map(|&x| cs.reg_name(x).unwrap()).collect();
     names.join(", ")
 }
 


### PR DESCRIPTION
Removed `Instructions::iter()` and `InstructionIterator`. The nice thing about having a deref to a slice is that it gives you an `iter()` method for free because of Rust's deref coercion. Also fixed some tests so that they use references to `Insn` instead and made `Insn` cloneable as well in case someone did want an `Iterator<Item = Insn>` instead of an `Iterator<Item = &Insn>`.