### PR TITLE
travis-ci: remove exclude section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,6 @@ before_cache:
   - rm -rf target/cov "$TRAVIS_HOME/.cargo/registry/src"
 
 matrix:
-  # Clear the whole matrix
-  exclude:
-    - os: linux
-    - os: osx
   # Add each target manually
   include:
     - os: linux

--- a/capstone-rs/ci/test.sh
+++ b/capstone-rs/ci/test.sh
@@ -145,7 +145,11 @@ cov() {
     KCOV=./kcov-install/usr/local/bin/kcov run_kcov
 
     if [[ "${TRAVIS_JOB_ID:+Z}" = Z ]]; then
-        bash <(curl -s https://codecov.io/bash)
+        codecov_script="$(mktemp)"
+        curl --silent --show-error "https://codecov.io/bash" \
+            > "${codecov_script}" \
+            || Error "Failed to download codecov script"
+        bash "${codecov_script}" || Error "Codecov script execution failed"
         echo "Uploaded code coverage"
     else
         echo "Not uploading coverage since we are not in a CI job"


### PR DESCRIPTION
Travis CI has changed how these are parsed, so now the exclude section
overrides the include, thus causing no Travis CI jobs to run.