### PR TITLE
Add a try_from implementation to convert from a cs_insn to an Insn

### DIFF
--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -209,6 +209,22 @@ pub struct Insn<'a> {
 pub struct InsnDetail<'a>(pub(crate) &'a cs_detail, pub(crate) Arch);
 
 impl<'a> Insn<'a> {
+    /// Create an Insn from a raw pointer to a capstone cs_insn.
+    ///
+    /// This function serves to allow integration with libraries which generate cs_insn's internally.
+    ///
+    /// Note that this function is unsafe, and assumes that you know what you are doing. In
+    /// particular, it generates a lifetime for the Insn from nothing, and that lifetime is in
+    /// no-way actually tied to the cs_insn itself. It is the responsibility of the caller to
+    /// ensure that the resulting Insn lives only as long as the cs_insn. This function
+    /// assumes that the pointer passed is non-null and a valid cs_insn pointer.
+    pub unsafe fn from_raw(insn: *const cs_insn) -> Self {
+        Self {
+            insn: *insn,
+            _marker: PhantomData,
+        }
+    }
+
     /// The mnemonic for the instruction
     pub fn mnemonic(&self) -> Option<&str> {
         unsafe { str_from_cstr_ptr(self.insn.mnemonic.as_ptr()) }

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -3092,3 +3092,22 @@ fn test_insn_size_and_alignment() {
         assert_eq!(original.id(), transmuted.id());
     }
 }
+
+#[test]
+fn test_insn_from_raw() {
+    use capstone_sys::cs_insn;
+
+    let cs = Capstone::new()
+        .x86()
+        .mode(x86::ArchMode::Mode64)
+        .build()
+        .unwrap();
+
+    let insns = cs.disasm_all(X86_CODE, START_TEST_ADDR).unwrap();
+    for insn in insns.iter() {
+        let raw_insn = &insn.insn as *const cs_insn;
+        let from_raw_insn = unsafe { Insn::from_raw(raw_insn) };
+        assert_eq!(format!("{:?}", from_raw_insn), format!("{:?}", insn));
+    }
+
+}


### PR DESCRIPTION
This PR adds a try_from implementation which allows one to convert from a raw `* const cs_insn` to an `Insn`.

We need this for @frida-rust, as frida generates `cs_insn`s internally, and we'd like to be able to use capstone-rs's rich API on those instructions.