### PR TITLE
cirrus-ci: upgrade FreeBSD image to 12.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-12-0-release-amd64
+  image: freebsd-12-2-release-amd64
 
 test_task:
   env:


### PR DESCRIPTION
Fixes issue seen for FreeBSD tests:

```
ld-elf.so.1: Undefined symbol "rl_filename_rewrite_hook" referenced from COPY relocation in /usr/local/bin/bash
```