### PR TITLE
Fix link to examples/ directory in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Found 4 instructions
     insn groups:
 ```
 
-To see more demos, see the [`examples/`](examples) directory.
+To see more demos, see the [`examples/`](capstone-rs/examples) directory.
 More complex demos welcome!
 
 # Features


### PR DESCRIPTION
It seems that the link was broken when the capstone-rs subdirectory was added.