### PR TITLE
Bump bindgen version and add wasm support

### DIFF
--- a/capstone-sys/Cargo.toml
+++ b/capstone-sys/Cargo.toml
@@ -26,7 +26,7 @@ travis-ci = { repository = "capstone-rust/capstone-sys" }
 libc = { version = "0.2.59", default-features = false }
 
 [build-dependencies]
-bindgen = { optional = true, version = "0.53.0" }
+bindgen = { optional = true, version = "0.57.0" }
 regex = { optional = true, version = "1.3.1" }
 cc = "1.0"
 

--- a/capstone-sys/build.rs
+++ b/capstone-sys/build.rs
@@ -130,6 +130,7 @@ fn build_capstone_cc() {
         .define("CAPSTONE_HAS_SPARC", None)
         .define("CAPSTONE_HAS_SYSZ", None)
         .define("CAPSTONE_HAS_TMS320C64X", None)
+        .define("CAPSTONE_HAS_WASM", None)
         .define("CAPSTONE_HAS_X86", None)
         .define("CAPSTONE_HAS_XCORE", None)
         .flag_if_supported("-Wno-unused-function")


### PR DESCRIPTION
Bumped the bindgen version used (as packages with newer bindgen were conflicting).

Added WASM support, as without it I was running into issues with missing WASM related symbols.
