### PR TITLE
arch: Implement size_hint for operand iterators

### DIFF
--- a/capstone-rs/src/arch/mod.rs
+++ b/capstone-rs/src/arch/mod.rs
@@ -632,6 +632,10 @@ macro_rules! def_arch_details_struct {
                     Some(op) => Some($Operand::from(op)),
                 }
             }
+
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                self.0.size_hint()
+            }
         }
 
         impl<'a> ExactSizeIterator for $OperandIteratorLife {


### PR DESCRIPTION
Noticed while profiling that vector resizing was pretty hot when disassembly and getting operands, and it appears to be due to operand iterators not implementing `size_hint`. We can simply delegate size_hint to the underlying iterator.