### PR TITLE
Refine Github Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           command: test
 
       - uses: actions-rs/cargo@v1
+        if: matrix.rust == 'stable'
         with:
           command: fmt
           args: --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           args: --all -- --check
 
       - uses: actions-rs/cargo@v1
-        if: matrix.rust == "stable"
+        if: matrix.rust == 'stable'
         with:
           command: clippy
           args: -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,21 +24,25 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - uses: actions-rs/cargo@v1
+      - name: cargo build
+        uses: actions-rs/cargo@v1
         with:
           command: build
 
-      - uses: actions-rs/cargo@v1
+      - name: cargo test
+        uses: actions-rs/cargo@v1
         with:
           command: test
 
-      - uses: actions-rs/cargo@v1
+      - name: cargo fmt
+        uses: actions-rs/cargo@v1
         if: matrix.rust == 'stable'
         with:
           command: fmt
           args: --all -- --check
 
-      - uses: actions-rs/cargo@v1
+      - name: cargo clippy
+        uses: actions-rs/cargo@v1
         if: matrix.rust == 'stable'
         with:
           command: clippy


### PR DESCRIPTION
Only run cargo fmt/clippy on stable toolchain. Also adds useful names to some tests.