### PR TITLE
Remove incorrect implementation of `Clone` for `Insn<'capstone>`

### DIFF
--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -162,7 +162,6 @@ impl<'a> Drop for Instructions<'a> {
 /// # Detail
 ///
 /// To learn how to get more instruction details, see [`InsnDetail`].
-#[derive(Clone)]
 #[repr(transparent)]
 pub struct Insn<'a> {
     /// Inner `cs_insn`


### PR DESCRIPTION
Fixes #121.

EDIT: superseded by #123 !

### Problem

The `Instructions<'capstone>` owned a heap-allocated `[Insn<'capstone>]` (imagine a `CsBox<[Insn<'capstone>]>`), which thus involves owning the backing storage for the `Insn`s themselves, as well as freeing whatever each `Insn<'capstone>` owns.

  - **What does a `Insn<'capstone>` own?** It turns out that as written, currently, it technically doesn't own anything, even if, semantically, it's owning kind of a `Option<CsBox<cs_detail>>`. That is, when its `detail` field is a non-`NULL` pointer, when the `CsBox<[Insns<'capstone>]>` is dropped, such non-`NULL` pointers are `cs_free`d as well.

    **So a `Insn<'capstone>`, conceptually, owns a `Box`-like-ish field. Mainly, a non-`Copy` field!**

  - and yet `Insn<'capstone>` implements `Clone`, by deriving it from the raw C field it wraps (which is `Copy`).

The only way doing that kind of thing could be fine would be if `Insn<'capstone>` were, actually, a `Insn<'instructions>`

  - Rant: should the lifetimes in the codebase have been properly named, this issue could have been identified and debugged more easily. As of now, we just have a gigantic soup of `'a`s _almost everywhere_ (sadly a code style, or rather, lack thereof, that the Rust book teaches), and the rare cases where there is no `'a`, it's even worse: we get `elided_lifetimes_lifetimes_in_paths` (which ought to be denied, as a Rust idiom since 2018).

    This, combined with `unsafe` code and these subtle ownership things, lead to this kind of situations, where we end up with an `Insn<'a>` type that some code treats as owning its `detail` fields (since it can outlive the `Instructions<'capstone>` it is derived from), and other code treats it as a borrow of `Instructions<'capstone>` (the `Clone`(-and-thus-`Copy`) semantics it currently has).

So either the lifetime signatures need to change to express that we have a `Insn<'instructions>` ("treat it as a borrow"), or the `Clone` needs to go ("treat is an owned thing").

Since the former would require getting rid of those handy `Deref` and `AsRef` impls (`Deref` / `AsRef` have a very limited, lifetime-wise, signature, that does not allow properly expressing the borrowing semantics desired here), I think it is just better to get rid of the latter.