### PR TITLE
Add not_diet feature

### DIFF
--- a/capstone-rs/Cargo.toml
+++ b/capstone-rs/Cargo.toml
@@ -29,5 +29,8 @@ harness = false
 
 [features]
 default = ["full"]
+# The 'full' feature, enabled by default, compiles Capstone normally. When disabled,
+# Capstone will be built in Diet mode (https://www.capstone-engine.org/diet.html).
+# This disables some features to reduce the size of the library
 full = ["capstone-sys/full"]
 use_bindgen = ["capstone-sys/use_bindgen"]

--- a/capstone-rs/Cargo.toml
+++ b/capstone-rs/Cargo.toml
@@ -28,6 +28,6 @@ name = "my_benchmark"
 harness = false
 
 [features]
-default = ["not_diet"]
-not_diet = ["capstone-sys/not_diet"]
+default = ["full"]
+full = ["capstone-sys/full"]
 use_bindgen = ["capstone-sys/use_bindgen"]

--- a/capstone-rs/Cargo.toml
+++ b/capstone-rs/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.11.0"
 travis-ci = { repository = "capstone-rust/capstone-rs" }
 
 [dependencies]
-capstone-sys = { path = "../capstone-sys", version = "0.15.0" }
+capstone-sys = { path = "../capstone-sys", version = "0.15.0",  default_features = false }
 libc = { version = "0.2", default-features = false }
 
 [dev-dependencies]
@@ -28,6 +28,6 @@ name = "my_benchmark"
 harness = false
 
 [features]
-default = []
-
+default = ["not_diet"]
+not_diet = ["capstone-sys/not_diet"]
 use_bindgen = ["capstone-sys/use_bindgen"]

--- a/capstone-rs/examples/demo.rs
+++ b/capstone-rs/examples/demo.rs
@@ -41,7 +41,7 @@ fn arch_example(cs: &mut Capstone, code: &[u8]) -> CsResult<()> {
             ("write regs:", reg_names(&cs, detail.regs_write())),
             ("insn groups:", group_names(&cs, detail.groups())),
         ];
-        
+
         #[cfg(not(feature = "not_diet"))]
         let output: &[(&str, String)] = &[
             ("insn id:", format!("{:?}", i.id().0)),

--- a/capstone-rs/examples/demo.rs
+++ b/capstone-rs/examples/demo.rs
@@ -7,12 +7,14 @@ const MIPS_CODE: &'static [u8] = b"\x56\x34\x21\x34\xc2\x17\x01\x00";
 
 const X86_CODE: &'static [u8] = b"\x55\x48\x8b\x05\xb8\x13\x00\x00\xe9\x14\x9e\x08\x00\x45\x31\xe4";
 
+#[cfg(feature = "not_diet")]
 /// Print register names
 fn reg_names(cs: &Capstone, regs: &[RegId]) -> String {
     let names: Vec<String> = regs.iter().map(|&x| cs.reg_name(x).unwrap()).collect();
     names.join(", ")
 }
 
+#[cfg(feature = "not_diet")]
 /// Print instruction group names
 fn group_names(cs: &Capstone, regs: &[InsnGroupId]) -> String {
     let names: Vec<String> = regs.iter().map(|&x| cs.group_name(x).unwrap()).collect();
@@ -31,12 +33,19 @@ fn arch_example(cs: &mut Capstone, code: &[u8]) -> CsResult<()> {
         let arch_detail: ArchDetail = detail.arch_detail();
         let ops = arch_detail.operands();
 
+        #[cfg(feature = "not_diet")]
         let output: &[(&str, String)] = &[
             ("insn id:", format!("{:?}", i.id().0)),
             ("bytes:", format!("{:?}", i.bytes())),
             ("read regs:", reg_names(&cs, detail.regs_read())),
             ("write regs:", reg_names(&cs, detail.regs_write())),
             ("insn groups:", group_names(&cs, detail.groups())),
+        ];
+        
+        #[cfg(not(feature = "not_diet"))]
+        let output: &[(&str, String)] = &[
+            ("insn id:", format!("{:?}", i.id().0)),
+            ("bytes:", format!("{:?}", i.bytes())),
         ];
 
         for &(ref name, ref message) in output.iter() {

--- a/capstone-rs/examples/demo.rs
+++ b/capstone-rs/examples/demo.rs
@@ -7,14 +7,14 @@ const MIPS_CODE: &'static [u8] = b"\x56\x34\x21\x34\xc2\x17\x01\x00";
 
 const X86_CODE: &'static [u8] = b"\x55\x48\x8b\x05\xb8\x13\x00\x00\xe9\x14\x9e\x08\x00\x45\x31\xe4";
 
-#[cfg(feature = "not_diet")]
+#[cfg(feature = "full")]
 /// Print register names
 fn reg_names(cs: &Capstone, regs: &[RegId]) -> String {
     let names: Vec<String> = regs.iter().map(|&x| cs.reg_name(x).unwrap()).collect();
     names.join(", ")
 }
 
-#[cfg(feature = "not_diet")]
+#[cfg(feature = "full")]
 /// Print instruction group names
 fn group_names(cs: &Capstone, regs: &[InsnGroupId]) -> String {
     let names: Vec<String> = regs.iter().map(|&x| cs.group_name(x).unwrap()).collect();
@@ -33,7 +33,7 @@ fn arch_example(cs: &mut Capstone, code: &[u8]) -> CsResult<()> {
         let arch_detail: ArchDetail = detail.arch_detail();
         let ops = arch_detail.operands();
 
-        #[cfg(feature = "not_diet")]
+        #[cfg(feature = "full")]
         let output: &[(&str, String)] = &[
             ("insn id:", format!("{:?}", i.id().0)),
             ("bytes:", format!("{:?}", i.bytes())),
@@ -42,7 +42,7 @@ fn arch_example(cs: &mut Capstone, code: &[u8]) -> CsResult<()> {
             ("insn groups:", group_names(&cs, detail.groups())),
         ];
 
-        #[cfg(not(feature = "not_diet"))]
+        #[cfg(not(feature = "full"))]
         let output: &[(&str, String)] = &[
             ("insn id:", format!("{:?}", i.id().0)),
             ("bytes:", format!("{:?}", i.bytes())),

--- a/capstone-rs/src/arch/m68k.rs
+++ b/capstone-rs/src/arch/m68k.rs
@@ -634,6 +634,7 @@ mod test {
         );
     }
 
+    #[cfg(feature = "not_diet")]
     #[test]
     fn extra_info() {
         use crate::arch::DetailsArchInsn;

--- a/capstone-rs/src/arch/m68k.rs
+++ b/capstone-rs/src/arch/m68k.rs
@@ -463,11 +463,9 @@ def_arch_details_struct!(
 #[cfg(test)]
 mod test {
     use super::*;
-    use alloc::vec::Vec;
     use capstone_sys::m68k_address_mode::*;
     use capstone_sys::m68k_op_type::*;
     use capstone_sys::m68k_reg::*;
-    use crate::instruction::*;
 
     const MEM_ZERO: m68k_op_mem = m68k_op_mem {
         base_reg: M68K_REG_INVALID,
@@ -637,6 +635,8 @@ mod test {
     #[cfg(feature = "not_diet")]
     #[test]
     fn extra_info() {
+        use alloc::vec::Vec;
+        use crate::instruction::*;
         use crate::arch::DetailsArchInsn;
 
         let cs = Capstone::new()

--- a/capstone-rs/src/arch/m68k.rs
+++ b/capstone-rs/src/arch/m68k.rs
@@ -632,7 +632,7 @@ mod test {
         );
     }
 
-    #[cfg(feature = "not_diet")]
+    #[cfg(feature = "full")]
     #[test]
     fn extra_info() {
         use alloc::vec::Vec;

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -1,8 +1,8 @@
-use alloc::string::{String, ToString};
+use alloc::string::String;
 use core::convert::From;
 use core::marker::PhantomData;
 
-use libc::{c_int, c_uint, c_void};
+use libc::{c_int, c_void};
 
 use capstone_sys::cs_opt_value::*;
 use capstone_sys::*;
@@ -10,8 +10,10 @@ use capstone_sys::*;
 use crate::arch::CapstoneBuilder;
 use crate::constants::{Arch, Endian, ExtraMode, Mode, OptValue, Syntax};
 use crate::error::*;
-use crate::ffi::str_from_cstr_ptr;
 use crate::instruction::{Insn, InsnDetail, InsnGroupId, InsnId, Instructions, RegId};
+
+#[cfg(feature = "not_diet")]
+use {libc::c_uint, crate::ffi::str_from_cstr_ptr, alloc::string::ToString};
 
 /// An instance of the capstone disassembler
 ///
@@ -342,6 +344,8 @@ impl Capstone {
         result
     }
 
+
+    #[cfg(feature = "not_diet")]
     /// Converts a register id `reg_id` to a `String` containing the register name.
     pub fn reg_name(&self, reg_id: RegId) -> Option<String> {
         let reg_name = unsafe {
@@ -352,6 +356,13 @@ impl Capstone {
         Some(reg_name)
     }
 
+    #[cfg(not(feature = "not_diet"))]
+    /// `cs_reg_name` is not available in Diet mode.
+    pub fn reg_name(&self, _: RegId) -> Option<String> {
+        None
+    }
+
+    #[cfg(feature = "not_diet")]
     /// Converts an instruction id `insn_id` to a `String` containing the instruction name.
     ///
     /// Note: This function ignores the current syntax and uses the default syntax.
@@ -364,6 +375,13 @@ impl Capstone {
         Some(insn_name)
     }
 
+    #[cfg(not(feature = "not_diet"))]
+    /// `cs_insn_name` is not available in Diet mode. This will always return `None`.
+    pub fn insn_name(&self, _: InsnId) -> Option<String> {
+        None
+    }
+
+    #[cfg(feature = "not_diet")]
     /// Converts a group id `group_id` to a `String` containing the group name.
     pub fn group_name(&self, group_id: InsnGroupId) -> Option<String> {
         let group_name = unsafe {
@@ -373,6 +391,14 @@ impl Capstone {
 
         Some(group_name)
     }
+
+    #[cfg(not(feature = "not_diet"))]
+    /// `cs_group_name` is not available in Diet mode. This will always return None.
+    pub fn group_name(&self, _: InsnGroupId) -> Option<String> {
+        None
+    }
+
+
 
     /// Returns `Detail` structure for a given instruction
     ///

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -403,14 +403,11 @@ impl Capstone {
     ///
     /// 1. Instruction was created with detail enabled
     /// 2. Skipdata is disabled
-    /// 3. Capstone was not compiled in diet mode
     pub fn insn_detail<'s, 'i: 's>(&'s self, insn: &'i Insn) -> CsResult<InsnDetail<'i>> {
         if !self.detail_enabled {
             Err(Error::DetailOff)
         } else if insn.id().0 == 0 {
             Err(Error::IrrelevantDataInSkipData)
-        } else if Self::is_diet() {
-            Err(Error::IrrelevantDataInDiet)
         } else {
             Ok(unsafe { insn.detail(self.arch) })
         }

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -12,7 +12,6 @@ use crate::constants::{Arch, Endian, ExtraMode, Mode, OptValue, Syntax};
 use crate::error::*;
 use crate::instruction::{Insn, InsnDetail, InsnGroupId, InsnId, Instructions, RegId};
 
-#[cfg(feature = "full")]
 use {crate::ffi::str_from_cstr_ptr, alloc::string::ToString, libc::c_uint};
 
 /// An instance of the capstone disassembler

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -12,7 +12,7 @@ use crate::constants::{Arch, Endian, ExtraMode, Mode, OptValue, Syntax};
 use crate::error::*;
 use crate::instruction::{Insn, InsnDetail, InsnGroupId, InsnId, Instructions, RegId};
 
-#[cfg(feature = "not_diet")]
+#[cfg(feature = "full")]
 use {crate::ffi::str_from_cstr_ptr, alloc::string::ToString, libc::c_uint};
 
 /// An instance of the capstone disassembler
@@ -344,57 +344,49 @@ impl Capstone {
         result
     }
 
-    #[cfg(feature = "not_diet")]
     /// Converts a register id `reg_id` to a `String` containing the register name.
+    /// Unavailable in Diet mode
     pub fn reg_name(&self, reg_id: RegId) -> Option<String> {
-        let reg_name = unsafe {
-            let _reg_name = cs_reg_name(self.csh(), c_uint::from(reg_id.0));
-            str_from_cstr_ptr(_reg_name)?.to_string()
-        };
-
-        Some(reg_name)
+        if cfg!(feature = "full") {
+            let reg_name = unsafe {
+                let _reg_name = cs_reg_name(self.csh(), c_uint::from(reg_id.0));
+                str_from_cstr_ptr(_reg_name)?.to_string()
+            };
+            Some(reg_name)
+        } else {
+            None
+        }
     }
 
-    #[cfg(not(feature = "not_diet"))]
-    /// `cs_reg_name` is not available in Diet mode.
-    pub fn reg_name(&self, _: RegId) -> Option<String> {
-        None
-    }
-
-    #[cfg(feature = "not_diet")]
     /// Converts an instruction id `insn_id` to a `String` containing the instruction name.
-    ///
+    /// Unavailable in Diet mode.
     /// Note: This function ignores the current syntax and uses the default syntax.
     pub fn insn_name(&self, insn_id: InsnId) -> Option<String> {
-        let insn_name = unsafe {
-            let _insn_name = cs_insn_name(self.csh(), insn_id.0 as c_uint);
-            str_from_cstr_ptr(_insn_name)?.to_string()
-        };
+        if cfg!(feature = "full") {
+            let insn_name = unsafe {
+                let _insn_name = cs_insn_name(self.csh(), insn_id.0 as c_uint);
+                str_from_cstr_ptr(_insn_name)?.to_string()
+            };
 
-        Some(insn_name)
+            Some(insn_name)
+        } else {
+            None
+        }
     }
 
-    #[cfg(not(feature = "not_diet"))]
-    /// `cs_insn_name` is not available in Diet mode. This will always return `None`.
-    pub fn insn_name(&self, _: InsnId) -> Option<String> {
-        None
-    }
-
-    #[cfg(feature = "not_diet")]
     /// Converts a group id `group_id` to a `String` containing the group name.
+    /// Unavailable in Diet mode
     pub fn group_name(&self, group_id: InsnGroupId) -> Option<String> {
-        let group_name = unsafe {
-            let _group_name = cs_group_name(self.csh(), c_uint::from(group_id.0));
-            str_from_cstr_ptr(_group_name)?.to_string()
-        };
+        if cfg!(feature = "full") {
+            let group_name = unsafe {
+                let _group_name = cs_group_name(self.csh(), c_uint::from(group_id.0));
+                str_from_cstr_ptr(_group_name)?.to_string()
+            };
 
-        Some(group_name)
-    }
-
-    #[cfg(not(feature = "not_diet"))]
-    /// `cs_group_name` is not available in Diet mode. This will always return None.
-    pub fn group_name(&self, _: InsnGroupId) -> Option<String> {
-        None
+            Some(group_name)
+        } else {
+            None
+        }
     }
 
     /// Returns `Detail` structure for a given instruction

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -13,7 +13,7 @@ use crate::error::*;
 use crate::instruction::{Insn, InsnDetail, InsnGroupId, InsnId, Instructions, RegId};
 
 #[cfg(feature = "not_diet")]
-use {libc::c_uint, crate::ffi::str_from_cstr_ptr, alloc::string::ToString};
+use {crate::ffi::str_from_cstr_ptr, alloc::string::ToString, libc::c_uint};
 
 /// An instance of the capstone disassembler
 ///
@@ -344,7 +344,6 @@ impl Capstone {
         result
     }
 
-
     #[cfg(feature = "not_diet")]
     /// Converts a register id `reg_id` to a `String` containing the register name.
     pub fn reg_name(&self, reg_id: RegId) -> Option<String> {
@@ -397,8 +396,6 @@ impl Capstone {
     pub fn group_name(&self, _: InsnGroupId) -> Option<String> {
         None
     }
-
-
 
     /// Returns `Detail` structure for a given instruction
     ///

--- a/capstone-rs/src/ffi.rs
+++ b/capstone-rs/src/ffi.rs
@@ -3,6 +3,8 @@
 use core::{slice, str};
 use libc::{self, c_char};
 
+// This function will go unused in Diet mode
+#[allow(unused)]
 /// Given a valid C-style, NUL terminated, UTF8-encoded string, returns a Rust `&str`
 ///
 /// Warnings:

--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -11,7 +11,6 @@ use capstone_sys::*;
 use crate::arch::ArchDetail;
 use crate::constants::Arch;
 
-#[cfg(feature = "full")]
 use crate::ffi::str_from_cstr_ptr;
 
 /// Represents a slice of [`Insn`] returned by [`Capstone`](crate::Capstone) `disasm*()` methods.

--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -11,7 +11,7 @@ use capstone_sys::*;
 use crate::arch::ArchDetail;
 use crate::constants::Arch;
 
-#[cfg(feature = "not_diet")]
+#[cfg(feature = "full")]
 use crate::ffi::str_from_cstr_ptr;
 
 /// Represents a slice of [`Insn`] returned by [`Capstone`](crate::Capstone) `disasm*()` methods.
@@ -227,26 +227,26 @@ impl<'a> Insn<'a> {
         }
     }
 
-    /// The mnemonic for the instruction
+    /// The mnemonic for the instruction.
+    /// Unavailable in Diet mode.
     #[inline]
     pub fn mnemonic(&self) -> Option<&str> {
-        #[cfg(feature = "not_diet")]
-        unsafe {
-            str_from_cstr_ptr(self.insn.mnemonic.as_ptr())
+        if cfg!(feature = "full") {
+            unsafe { str_from_cstr_ptr(self.insn.mnemonic.as_ptr()) }
+        } else {
+            None
         }
-        #[cfg(not(feature = "not_diet"))]
-        return None;
     }
 
-    /// The operand string associated with the instruction
+    /// The operand string associated with the instruction.
+    /// Unavailable in Diet mode.
     #[inline]
     pub fn op_str(&self) -> Option<&str> {
-        #[cfg(feature = "not_diet")]
-        unsafe {
-            str_from_cstr_ptr(self.insn.op_str.as_ptr())
+        if cfg!(feature = "full") {
+            unsafe { str_from_cstr_ptr(self.insn.op_str.as_ptr()) }
+        } else {
+            None
         }
-        #[cfg(not(feature = "not_diet"))]
-        return None;
     }
 
     /// Access instruction id
@@ -381,7 +381,7 @@ impl<'a> Display for OwnedInsn<'a> {
 pub struct InsnGroupIter<'a>(slice::Iter<'a, InsnGroupIdInt>);
 
 impl<'a> InsnDetail<'a> {
-    #[cfg(feature = "not_diet")]
+    #[cfg(feature = "full")]
     /// Returns the implicit read registers
     pub fn regs_read(&self) -> &[RegId] {
         unsafe {
@@ -390,7 +390,7 @@ impl<'a> InsnDetail<'a> {
         }
     }
 
-    #[cfg(feature = "not_diet")]
+    #[cfg(feature = "full")]
     /// Returns the implicit write registers
     pub fn regs_write(&self) -> &[RegId] {
         unsafe {
@@ -399,7 +399,7 @@ impl<'a> InsnDetail<'a> {
         }
     }
 
-    #[cfg(feature = "not_diet")]
+    #[cfg(feature = "full")]
     /// Returns the groups to which this instruction belongs
     pub fn groups(&self) -> &[InsnGroupId] {
         unsafe {
@@ -445,7 +445,7 @@ impl<'a> InsnDetail<'a> {
     }
 }
 
-#[cfg(feature = "not_diet")]
+#[cfg(feature = "full")]
 impl<'a> Debug for InsnDetail<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         fmt.debug_struct("Detail")
@@ -456,7 +456,7 @@ impl<'a> Debug for InsnDetail<'a> {
     }
 }
 
-#[cfg(not(feature = "not_diet"))]
+#[cfg(not(feature = "full"))]
 impl<'a> Debug for InsnDetail<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         fmt.debug_struct("Detail").finish()

--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -231,7 +231,9 @@ impl<'a> Insn<'a> {
     #[inline]
     pub fn mnemonic(&self) -> Option<&str> {
         #[cfg(feature = "not_diet")]
-        unsafe { str_from_cstr_ptr(self.insn.mnemonic.as_ptr()) }
+        unsafe {
+            str_from_cstr_ptr(self.insn.mnemonic.as_ptr())
+        }
         #[cfg(not(feature = "not_diet"))]
         return None;
     }
@@ -240,7 +242,9 @@ impl<'a> Insn<'a> {
     #[inline]
     pub fn op_str(&self) -> Option<&str> {
         #[cfg(feature = "not_diet")]
-        unsafe { str_from_cstr_ptr(self.insn.op_str.as_ptr()) }
+        unsafe {
+            str_from_cstr_ptr(self.insn.op_str.as_ptr())
+        }
         #[cfg(not(feature = "not_diet"))]
         return None;
     }

--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -10,6 +10,8 @@ use capstone_sys::*;
 
 use crate::arch::ArchDetail;
 use crate::constants::Arch;
+
+#[cfg(feature = "not_diet")]
 use crate::ffi::str_from_cstr_ptr;
 
 /// Represents a slice of [`Insn`] returned by [`Capstone`](crate::Capstone) `disasm*()` methods.
@@ -228,13 +230,19 @@ impl<'a> Insn<'a> {
     /// The mnemonic for the instruction
     #[inline]
     pub fn mnemonic(&self) -> Option<&str> {
+        #[cfg(feature = "not_diet")]
         unsafe { str_from_cstr_ptr(self.insn.mnemonic.as_ptr()) }
+        #[cfg(not(feature = "not_diet"))]
+        return None;
     }
 
     /// The operand string associated with the instruction
     #[inline]
     pub fn op_str(&self) -> Option<&str> {
+        #[cfg(feature = "not_diet")]
         unsafe { str_from_cstr_ptr(self.insn.op_str.as_ptr()) }
+        #[cfg(not(feature = "not_diet"))]
+        return None;
     }
 
     /// Access instruction id
@@ -330,6 +338,7 @@ impl<'a> Debug for Insn<'a> {
             .finish()
     }
 }
+
 impl<'a> Display for Insn<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         write!(fmt, "{:#x}: ", self.address())?;
@@ -356,6 +365,7 @@ impl<'a> Debug for OwnedInsn<'a> {
         Debug::fmt(&self.deref(), fmt)
     }
 }
+
 impl<'a> Display for OwnedInsn<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         Display::fmt(&self.deref(), fmt)
@@ -367,6 +377,7 @@ impl<'a> Display for OwnedInsn<'a> {
 pub struct InsnGroupIter<'a>(slice::Iter<'a, InsnGroupIdInt>);
 
 impl<'a> InsnDetail<'a> {
+    #[cfg(feature = "not_diet")]
     /// Returns the implicit read registers
     pub fn regs_read(&self) -> &[RegId] {
         unsafe {
@@ -375,6 +386,7 @@ impl<'a> InsnDetail<'a> {
         }
     }
 
+    #[cfg(feature = "not_diet")]
     /// Returns the implicit write registers
     pub fn regs_write(&self) -> &[RegId] {
         unsafe {
@@ -383,6 +395,7 @@ impl<'a> InsnDetail<'a> {
         }
     }
 
+    #[cfg(feature = "not_diet")]
     /// Returns the groups to which this instruction belongs
     pub fn groups(&self) -> &[InsnGroupId] {
         unsafe {
@@ -428,6 +441,7 @@ impl<'a> InsnDetail<'a> {
     }
 }
 
+#[cfg(feature = "not_diet")]
 impl<'a> Debug for InsnDetail<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         fmt.debug_struct("Detail")
@@ -435,6 +449,13 @@ impl<'a> Debug for InsnDetail<'a> {
             .field("regs_write", &self.regs_write())
             .field("groups", &self.groups())
             .finish()
+    }
+}
+
+#[cfg(not(feature = "not_diet"))]
+impl<'a> Debug for InsnDetail<'a> {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        fmt.debug_struct("Detail").finish()
     }
 }
 

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -225,7 +225,6 @@ fn test_instruction_helper(
     assert_eq!(bytes, insn.bytes());
 }
 
-
 #[cfg_attr(not(feature = "not_diet"), allow(unused_variables))]
 fn test_instruction_detail_helper<T>(
     cs: &Capstone,
@@ -235,7 +234,6 @@ fn test_instruction_detail_helper<T>(
 ) where
     T: Into<ArchOperand> + Clone,
 {
-
     // Check mnemonic
     #[cfg(feature = "not_diet")]
     if has_default_syntax {

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -1,4 +1,3 @@
-use alloc::string::String;
 use alloc::vec::Vec;
 
 use capstone_sys::cs_group_type;
@@ -27,7 +26,9 @@ fn test_x86_simple() {
             Ok(insns) => {
                 assert_eq!(insns.len(), 2);
                 let is: Vec<_> = insns.iter().collect();
+                #[cfg(feature = "not_diet")]
                 assert_eq!(is[0].mnemonic().unwrap(), "push");
+                #[cfg(feature = "not_diet")]
                 assert_eq!(is[1].mnemonic().unwrap(), "mov");
 
                 assert_eq!(is[0].address(), START_TEST_ADDR);
@@ -51,7 +52,9 @@ fn test_arm_simple() {
             Ok(insns) => {
                 assert_eq!(insns.len(), 2);
                 let is: Vec<_> = insns.iter().collect();
+                #[cfg(feature = "not_diet")]
                 assert_eq!(is[0].mnemonic().unwrap(), "streq");
+                #[cfg(feature = "not_diet")]
                 assert_eq!(is[1].mnemonic().unwrap(), "strheq");
 
                 assert_eq!(is[0].address(), START_TEST_ADDR);
@@ -75,8 +78,10 @@ fn test_arm64_none() {
     assert!(cs.disasm_all(ARM_CODE, START_TEST_ADDR).unwrap().is_empty());
 }
 
+#[cfg(feature = "not_diet")]
 #[test]
 fn test_x86_names() {
+    use alloc::string::String;
     match Capstone::new().x86().mode(x86::ArchMode::Mode32).build() {
         Ok(cs) => {
             let reg_id = RegId(1);
@@ -149,6 +154,7 @@ fn test_skipdata() {
     assert_eq!(insns[1].id().0, x86_insn::X86_INS_INSB as u32);
 }
 
+#[cfg(feature = "not_diet")]
 #[test]
 fn test_detail_true() {
     let mut cs1 = Capstone::new()
@@ -179,7 +185,6 @@ fn test_detail_true() {
             let detail = cs
                 .insn_detail(&insns[insn_idx])
                 .expect("Unable to get detail");
-            #[cfg(feature = "not_diet")]
             {
                 let groups = detail.groups();
                 for insn_group_id in &insn_group_ids {
@@ -191,6 +196,7 @@ fn test_detail_true() {
     }
 }
 
+#[cfg_attr(not(feature = "not_diet"), allow(unused_variables))]
 fn test_instruction_helper(
     cs: &Capstone,
     insn: &Insn,
@@ -201,12 +207,14 @@ fn test_instruction_helper(
     println!("{:?}", insn);
 
     // Check mnemonic
+    #[cfg(feature = "not_diet")]
     if has_default_syntax {
         // insn_name() does not respect current syntax
         // does not always match the internal mnemonic
         cs.insn_name(insn.id())
             .expect("Failed to get instruction name");
     }
+    #[cfg(feature = "not_diet")]
     assert_eq!(
         mnemonic_name,
         insn.mnemonic().expect("Failed to get mnemonic"),
@@ -217,6 +225,8 @@ fn test_instruction_helper(
     assert_eq!(bytes, insn.bytes());
 }
 
+
+#[cfg_attr(not(feature = "not_diet"), allow(unused_variables))]
 fn test_instruction_detail_helper<T>(
     cs: &Capstone,
     insn: &Insn,
@@ -225,13 +235,16 @@ fn test_instruction_detail_helper<T>(
 ) where
     T: Into<ArchOperand> + Clone,
 {
+
     // Check mnemonic
+    #[cfg(feature = "not_diet")]
     if has_default_syntax {
         // insn_name() does not respect current syntax
         // does not always match the internal mnemonic
         cs.insn_name(insn.id())
             .expect("Failed to get instruction name");
     }
+    #[cfg(feature = "not_diet")]
     assert_eq!(
         info.mnemonic,
         insn.mnemonic().expect("Failed to get mnemonic"),
@@ -326,6 +339,7 @@ fn test_instruction_group_helper<R: Copy + Into<RegId>>(
     );
 }
 
+#[cfg_attr(not(feature = "not_diet"), allow(unused_variables))]
 fn instructions_match_group<R: Copy + Into<RegId>>(
     cs: &mut Capstone,
     expected_insns: &[(&str, &[u8], &[cs_group_type::Type], &[R], &[R])],
@@ -489,12 +503,13 @@ fn test_instruction_details() {
     instructions_match_group(&mut cs, expected_insns, true);
 }
 
+#[cfg_attr(not(feature = "not_diet"), allow(unused_variables))]
 fn test_insns_match(cs: &mut Capstone, insns: &[(&str, &[u8])]) {
     for &(mnemonic, bytes) in insns.iter() {
         let insns = cs.disasm_all(bytes, START_TEST_ADDR).unwrap();
         assert_eq!(insns.len(), 1);
-        let insn = insns.iter().next().unwrap();
-        assert_eq!(insn.mnemonic(), Some(mnemonic));
+        #[cfg(feature = "not_diet")]
+        assert_eq!(insns.iter().next().unwrap().mnemonic(), Some(mnemonic));
     }
 }
 
@@ -559,8 +574,8 @@ fn test_arch_mode_endian_insns(
     instructions_match(&mut cs_raw, expected_insns.as_slice(), true);
     instructions_match(&mut cs_raw_endian_set, expected_insns.as_slice(), true);
 }
-
-#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "not_diet", derive(Copy, Clone, Debug))]
+#[cfg_attr(not(feature = "not_diet"), derive(Copy, Clone), allow(unused))]
 struct DetailedInsnInfo<'a, T: 'a + Into<ArchOperand>> {
     pub mnemonic: &'a str,
     pub bytes: &'a [u8],
@@ -601,6 +616,7 @@ fn test_arch_mode_endian_insns_detail<T>(
     instructions_match_detail(cs, insns, true);
 }
 
+#[cfg(feature = "not_diet")]
 #[test]
 fn test_syntax() {
     use crate::arch::x86::X86Reg;

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -1,6 +1,5 @@
 use alloc::string::String;
 use alloc::vec::Vec;
-use std::collections::HashSet;
 
 use capstone_sys::cs_group_type;
 use libc::c_uint;
@@ -180,10 +179,13 @@ fn test_detail_true() {
             let detail = cs
                 .insn_detail(&insns[insn_idx])
                 .expect("Unable to get detail");
-            let groups = detail.groups();
-            for insn_group_id in &insn_group_ids {
-                let insn_group = InsnGroupId(*insn_group_id as InsnGroupIdInt);
-                assert_eq!(groups.contains(&insn_group), false);
+            #[cfg(feature = "not_diet")]
+            {
+                let groups = detail.groups();
+                for insn_group_id in &insn_group_ids {
+                    let insn_group = InsnGroupId(*insn_group_id as InsnGroupIdInt);
+                    assert_eq!(groups.contains(&insn_group), false);
+                }
             }
         }
     }
@@ -260,6 +262,7 @@ fn test_instruction_detail_helper<T>(
     );
 }
 
+#[cfg(feature = "not_diet")]
 /// Assert instruction belongs or does not belong to groups, testing both insn_belongs_to_group
 /// and insn_group_ids
 fn test_instruction_group_helper<R: Copy + Into<RegId>>(
@@ -272,6 +275,7 @@ fn test_instruction_group_helper<R: Copy + Into<RegId>>(
     expected_regs_write: &[R],
     has_default_syntax: bool,
 ) {
+    use std::collections::HashSet;
     test_instruction_helper(&cs, insn, mnemonic_name, bytes, has_default_syntax);
     let detail = cs.insn_detail(insn).expect("Unable to get detail");
 
@@ -344,6 +348,7 @@ fn instructions_match_group<R: Copy + Into<RegId>>(
     // Check number of instructions
     assert_eq!(insns.len(), expected_insns.len());
 
+    #[cfg(feature = "not_diet")]
     for (
         insn,
         &(

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -1,4 +1,6 @@
 use alloc::vec::Vec;
+#[cfg(feature = "full")]
+use {alloc::string::String, std::collections::HashSet};
 
 use capstone_sys::cs_group_type;
 use libc::c_uint;
@@ -26,11 +28,11 @@ fn test_x86_simple() {
             Ok(insns) => {
                 assert_eq!(insns.len(), 2);
                 let is: Vec<_> = insns.iter().collect();
-                #[cfg(feature = "not_diet")]
-                assert_eq!(is[0].mnemonic().unwrap(), "push");
-                #[cfg(feature = "not_diet")]
-                assert_eq!(is[1].mnemonic().unwrap(), "mov");
-
+                #[cfg(feature = "full")]
+                {
+                    assert_eq!(is[0].mnemonic().unwrap(), "push");
+                    assert_eq!(is[1].mnemonic().unwrap(), "mov");
+                }
                 assert_eq!(is[0].address(), START_TEST_ADDR);
                 assert_eq!(is[1].address(), START_TEST_ADDR + 1);
 
@@ -52,11 +54,11 @@ fn test_arm_simple() {
             Ok(insns) => {
                 assert_eq!(insns.len(), 2);
                 let is: Vec<_> = insns.iter().collect();
-                #[cfg(feature = "not_diet")]
-                assert_eq!(is[0].mnemonic().unwrap(), "streq");
-                #[cfg(feature = "not_diet")]
-                assert_eq!(is[1].mnemonic().unwrap(), "strheq");
-
+                #[cfg(feature = "full")]
+                {
+                    assert_eq!(is[0].mnemonic().unwrap(), "streq");
+                    assert_eq!(is[1].mnemonic().unwrap(), "strheq");
+                }
                 assert_eq!(is[0].address(), START_TEST_ADDR);
                 assert_eq!(is[1].address(), START_TEST_ADDR + 4);
             }
@@ -78,10 +80,9 @@ fn test_arm64_none() {
     assert!(cs.disasm_all(ARM_CODE, START_TEST_ADDR).unwrap().is_empty());
 }
 
-#[cfg(feature = "not_diet")]
+#[cfg(feature = "full")]
 #[test]
 fn test_x86_names() {
-    use alloc::string::String;
     match Capstone::new().x86().mode(x86::ArchMode::Mode32).build() {
         Ok(cs) => {
             let reg_id = RegId(1);
@@ -154,7 +155,7 @@ fn test_skipdata() {
     assert_eq!(insns[1].id().0, x86_insn::X86_INS_INSB as u32);
 }
 
-#[cfg(feature = "not_diet")]
+#[cfg(feature = "full")]
 #[test]
 fn test_detail_true() {
     let mut cs1 = Capstone::new()
@@ -181,22 +182,17 @@ fn test_detail_true() {
             cs_group_type::CS_GRP_INT,
             cs_group_type::CS_GRP_IRET,
         ];
-        for insn_idx in 0..1 + 1 {
-            let detail = cs
-                .insn_detail(&insns[insn_idx])
-                .expect("Unable to get detail");
-            {
-                let groups = detail.groups();
-                for insn_group_id in &insn_group_ids {
-                    let insn_group = InsnGroupId(*insn_group_id as InsnGroupIdInt);
-                    assert_eq!(groups.contains(&insn_group), false);
-                }
+        for insn in insns.iter() {
+            let detail = cs.insn_detail(insn).expect("Unable to get detail");
+            let groups = detail.groups();
+            for insn_group_id in &insn_group_ids {
+                let insn_group = InsnGroupId(*insn_group_id as InsnGroupIdInt);
+                assert!(!groups.contains(&insn_group));
             }
         }
     }
 }
 
-#[cfg_attr(not(feature = "not_diet"), allow(unused_variables))]
 fn test_instruction_helper(
     cs: &Capstone,
     insn: &Insn,
@@ -207,14 +203,13 @@ fn test_instruction_helper(
     println!("{:?}", insn);
 
     // Check mnemonic
-    #[cfg(feature = "not_diet")]
-    if has_default_syntax {
+    if has_default_syntax && cfg!(feature = "full") {
         // insn_name() does not respect current syntax
         // does not always match the internal mnemonic
         cs.insn_name(insn.id())
             .expect("Failed to get instruction name");
     }
-    #[cfg(feature = "not_diet")]
+    #[cfg(feature = "full")]
     assert_eq!(
         mnemonic_name,
         insn.mnemonic().expect("Failed to get mnemonic"),
@@ -225,7 +220,6 @@ fn test_instruction_helper(
     assert_eq!(bytes, insn.bytes());
 }
 
-#[cfg_attr(not(feature = "not_diet"), allow(unused_variables))]
 fn test_instruction_detail_helper<T>(
     cs: &Capstone,
     insn: &Insn,
@@ -235,14 +229,13 @@ fn test_instruction_detail_helper<T>(
     T: Into<ArchOperand> + Clone,
 {
     // Check mnemonic
-    #[cfg(feature = "not_diet")]
-    if has_default_syntax {
+    if has_default_syntax && cfg!(feature = "full") {
         // insn_name() does not respect current syntax
         // does not always match the internal mnemonic
         cs.insn_name(insn.id())
             .expect("Failed to get instruction name");
     }
-    #[cfg(feature = "not_diet")]
+    #[cfg(feature = "full")]
     assert_eq!(
         info.mnemonic,
         insn.mnemonic().expect("Failed to get mnemonic"),
@@ -273,7 +266,7 @@ fn test_instruction_detail_helper<T>(
     );
 }
 
-#[cfg(feature = "not_diet")]
+#[cfg(feature = "full")]
 /// Assert instruction belongs or does not belong to groups, testing both insn_belongs_to_group
 /// and insn_group_ids
 fn test_instruction_group_helper<R: Copy + Into<RegId>>(
@@ -286,7 +279,6 @@ fn test_instruction_group_helper<R: Copy + Into<RegId>>(
     expected_regs_write: &[R],
     has_default_syntax: bool,
 ) {
-    use std::collections::HashSet;
     test_instruction_helper(&cs, insn, mnemonic_name, bytes, has_default_syntax);
     let detail = cs.insn_detail(insn).expect("Unable to get detail");
 
@@ -337,7 +329,6 @@ fn test_instruction_group_helper<R: Copy + Into<RegId>>(
     );
 }
 
-#[cfg_attr(not(feature = "not_diet"), allow(unused_variables))]
 fn instructions_match_group<R: Copy + Into<RegId>>(
     cs: &mut Capstone,
     expected_insns: &[(&str, &[u8], &[cs_group_type::Type], &[R], &[R])],
@@ -360,7 +351,7 @@ fn instructions_match_group<R: Copy + Into<RegId>>(
     // Check number of instructions
     assert_eq!(insns.len(), expected_insns.len());
 
-    #[cfg(feature = "not_diet")]
+    #[cfg(feature = "full")]
     for (
         insn,
         &(
@@ -501,12 +492,11 @@ fn test_instruction_details() {
     instructions_match_group(&mut cs, expected_insns, true);
 }
 
-#[cfg_attr(not(feature = "not_diet"), allow(unused_variables))]
 fn test_insns_match(cs: &mut Capstone, insns: &[(&str, &[u8])]) {
     for &(mnemonic, bytes) in insns.iter() {
         let insns = cs.disasm_all(bytes, START_TEST_ADDR).unwrap();
         assert_eq!(insns.len(), 1);
-        #[cfg(feature = "not_diet")]
+        #[cfg(feature = "full")]
         assert_eq!(insns.iter().next().unwrap().mnemonic(), Some(mnemonic));
     }
 }
@@ -572,8 +562,8 @@ fn test_arch_mode_endian_insns(
     instructions_match(&mut cs_raw, expected_insns.as_slice(), true);
     instructions_match(&mut cs_raw_endian_set, expected_insns.as_slice(), true);
 }
-#[cfg_attr(feature = "not_diet", derive(Copy, Clone, Debug))]
-#[cfg_attr(not(feature = "not_diet"), derive(Copy, Clone), allow(unused))]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "full", derive(Debug))]
 struct DetailedInsnInfo<'a, T: 'a + Into<ArchOperand>> {
     pub mnemonic: &'a str,
     pub bytes: &'a [u8],
@@ -614,7 +604,7 @@ fn test_arch_mode_endian_insns_detail<T>(
     instructions_match_detail(cs, insns, true);
 }
 
-#[cfg(feature = "not_diet")]
+#[cfg(feature = "full")]
 #[test]
 fn test_syntax() {
     use crate::arch::x86::X86Reg;

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -193,6 +193,7 @@ fn test_detail_true() {
     }
 }
 
+#[allow(unused)]
 fn test_instruction_helper(
     cs: &Capstone,
     insn: &Insn,
@@ -329,6 +330,7 @@ fn test_instruction_group_helper<R: Copy + Into<RegId>>(
     );
 }
 
+#[allow(unused)]
 fn instructions_match_group<R: Copy + Into<RegId>>(
     cs: &mut Capstone,
     expected_insns: &[(&str, &[u8], &[cs_group_type::Type], &[R], &[R])],
@@ -492,6 +494,7 @@ fn test_instruction_details() {
     instructions_match_group(&mut cs, expected_insns, true);
 }
 
+#[allow(unused)]
 fn test_insns_match(cs: &mut Capstone, insns: &[(&str, &[u8])]) {
     for &(mnemonic, bytes) in insns.iter() {
         let insns = cs.disasm_all(bytes, START_TEST_ADDR).unwrap();
@@ -562,6 +565,8 @@ fn test_arch_mode_endian_insns(
     instructions_match(&mut cs_raw, expected_insns.as_slice(), true);
     instructions_match(&mut cs_raw_endian_set, expected_insns.as_slice(), true);
 }
+
+#[allow(unused)]
 #[derive(Copy, Clone)]
 #[cfg_attr(feature = "full", derive(Debug))]
 struct DetailedInsnInfo<'a, T: 'a + Into<ArchOperand>> {

--- a/capstone-sys/Cargo.toml
+++ b/capstone-sys/Cargo.toml
@@ -31,7 +31,7 @@ regex = { optional = true, version = "1.3.1" }
 cc = "1.0"
 
 [features]
+default = ["not_diet"]
+not_diet = []
 # use pre-generated bindings instead of dynamically with bindgen
-default = []
-
 use_bindgen = ["bindgen", "regex"]  # Dynamically generate bindings with bindgen

--- a/capstone-sys/Cargo.toml
+++ b/capstone-sys/Cargo.toml
@@ -31,7 +31,7 @@ regex = { optional = true, version = "1.3.1" }
 cc = "1.0"
 
 [features]
-default = ["not_diet"]
-not_diet = []
+default = ["full"]
+full = []
 # use pre-generated bindings instead of dynamically with bindgen
 use_bindgen = ["bindgen", "regex"]  # Dynamically generate bindings with bindgen

--- a/capstone-sys/build.rs
+++ b/capstone-sys/build.rs
@@ -136,8 +136,10 @@ fn build_capstone_cc() {
         // No need to display any warnings from the C library
         .flag_if_supported("-w")
         .static_crt(use_static_crt);
-    #[cfg(not(feature = "not_diet"))]
-    builder.define("CAPSTONE_DIET", "no");
+    
+    if !cfg!(feature = "full") {
+        builder.define("CAPSTONE_DIET", "yes");
+    }
 
     builder.compile("capstone");
 }

--- a/cstool/Cargo.toml
+++ b/cstool/Cargo.toml
@@ -14,3 +14,7 @@ stderrlog = "0.5"
 version = "2.32"
 default-features = false
 features = []
+
+[features]
+default = ["full"]
+full = ["capstone/full"]


### PR DESCRIPTION
This PR adds a new default feature, `not_diet` to both crates. If *disabled*, Capstone will be compiled in Diet mode, which would result in speed/size improvements. Currently, many tests will fail if run with this feature disabled, and will need to be gated behind it.

It might be more legible to invert this feature `#[cfg(feature = "diet")]` but I believe Cargo's dependency resolution [requires](https://www.reddit.com/r/rust/comments/sgegah/cargo_features_have_to_be_additive/) that features always _add_ new items, rather than removing them.

Rather than directly returning `None`, we could instead defer to Capstone's API (returning NULL pointers or empty strings) - this way is more explicit but with more repeated code.