### PR TITLE
Updated README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ See the [`capstone-sys`](capstone-sys) page for the requirements and supported p
 ```rust
 extern crate capstone;
 
-use capstone::prelude::*;
+use capstone::{prelude::*, RegsIter, InsnGroupIter};
 
 const X86_CODE: &'static [u8] = b"\x55\x48\x8b\x05\xb8\x13\x00\x00\xe9\x14\x9e\x08\x00\x45\x31\xe4";
 
 /// Print register names
-fn reg_names(cs: &Capstone, regs: &[RegId]) -> String {
-    let names: Vec<String> = regs.iter().map(|&x| cs.reg_name(x).unwrap()).collect();
+fn reg_names(cs: &Capstone, regs: RegsIter<u16>) -> String {
+    let names: Vec<String> = regs.map(|x| cs.reg_name(x).unwrap()).collect();
     names.join(", ")
 }
 
 /// Print instruction group names
-fn group_names(cs: &Capstone, regs: &[InsnGroupId]) -> String {
-    let names: Vec<String> = regs.iter().map(|&x| cs.group_name(x).unwrap()).collect();
+fn group_names(cs: &Capstone, regs: InsnGroupIter<>) -> String {
+    let names: Vec<String> = regs.map(|x| cs.group_name(x).unwrap()).collect();
     names.join(", ")
 }
 
@@ -94,24 +94,42 @@ Produces:
 Found 4 instructions
 
 0x1000: pushq %rbp
+    insn id:     609
+    bytes:       [85]
     read regs:   rsp
     write regs:  rsp
     insn groups: mode64
+    operands: 1
+        X86Operand(X86Operand { size: 8, access: Some(ReadOnly), avx_bcast: X86_AVX_BCAST_INVALID, avx_zero_opmask: false, op_type: Reg(RegId(36)) })
 
 0x1001: movq 0x13b8(%rip), %rax
+    insn id:     460
+    bytes:       [72, 139, 5, 184, 19, 0, 0]
     read regs:
     write regs:
     insn groups:
+    operands: 2
+        X86Operand(X86Operand { size: 8, access: Some(ReadOnly), avx_bcast: X86_AVX_BCAST_INVALID, avx_zero_opmask: false, op_type: Mem(X86OpMem(x86_op_mem { segment: 0, base: 41, index: 0, scale: 1, disp: 5048 })) })
+        X86Operand(X86Operand { size: 8, access: Some(WriteOnly), avx_bcast: X86_AVX_BCAST_INVALID, avx_zero_opmask: false, op_type: Reg(RegId(35)) })
 
 0x1008: jmp 0x8ae21
+    insn id:     172
+    bytes:       [233, 20, 158, 8, 0]
     read regs:
     write regs:
-    insn groups: jump
+    insn groups: branch_relative, jump
+    operands: 1
+        X86Operand(X86Operand { size: 8, access: None, avx_bcast: X86_AVX_BCAST_INVALID, avx_zero_opmask: false, op_type: Imm(568865) })
 
 0x100d: xorl %r12d, %r12d
+    insn id:     1503
+    bytes:       [69, 49, 228]
     read regs:
     write regs:  rflags
     insn groups:
+    operands: 2
+        X86Operand(X86Operand { size: 4, access: Some(ReadOnly), avx_bcast: X86_AVX_BCAST_INVALID, avx_zero_opmask: false, op_type: Reg(RegId(230)) })
+        X86Operand(X86Operand { size: 4, access: Some(ReadWrite), avx_bcast: X86_AVX_BCAST_INVALID, avx_zero_opmask: false, op_type: Reg(RegId(230)) })
 ```
 
 To see more demos, see the [`examples/`](capstone-rs/examples) directory.


### PR DESCRIPTION
I was having difficulty getting the README example to compile. I had a look and I believe that this was because reg_names and group_names were expecting RegsID and IsnsGroupID respectively. 

I had a look and InsnDetail.regs_read(), and InsnDetail.regs_write() were returning RegsIter. While InsnDetail.groups() was returning  InsnGroupIter. So, I have updated the README to reflect this. If this is incorrect understanding of operation, please let me know. Thank you