### PR TITLE
Add option to build frida capstone bindings from git

### DIFF
--- a/capstone-rs/Cargo.toml
+++ b/capstone-rs/Cargo.toml
@@ -34,3 +34,4 @@ default = ["full"]
 # This disables some features to reduce the size of the library
 full = ["capstone-sys/full"]
 use_bindgen = ["capstone-sys/use_bindgen"]
+frida = ["use_bindgen", "capstone-sys/frida"] # Clone frida's capstone fork from git instead of using upstream capstone

--- a/capstone-rs/src/arch/arm64.rs
+++ b/capstone-rs/src/arch/arm64.rs
@@ -22,6 +22,8 @@ pub use capstone_sys::arm64_barrier_op as ArmBarrierOp;
 pub use capstone_sys::arm64_sysreg as Arm64Sysreg;
 pub use capstone_sys::arm64_sys_op as Arm64SysOp;
 pub use capstone_sys::arm64_barrier_op as Arm64BarrierOp;
+//TODO: pub use capstone_sys::arm64_svcr_op as Arm64SvcrOp;
+//TODO: pub use capstone_sys::arm64_op_sme_index as Arm64SmeIndexOp;
 
 use capstone_sys::cs_arm64_op__bindgen_ty_2;
 use capstone_sys::arm64_shifter;
@@ -69,6 +71,12 @@ impl Arm64OperandType {
             ARM64_OP_SYS => Sys(unsafe { value.sys }),
             ARM64_OP_PREFETCH => Prefetch(unsafe { value.prefetch }),
             ARM64_OP_BARRIER => Barrier(unsafe { value.barrier }),
+            // TODO: This likely needs to be filled with the proper value
+            #[cfg(feature = "frida")]
+            ARM64_OP_SVCR => Svcr,
+            //TODO: More missing values (unsafe {value.sme_index}),
+            #[cfg(feature = "frida")]
+            ARM64_OP_SME_INDEX => SmeIndex,
         }
     }
 }
@@ -127,6 +135,14 @@ pub enum Arm64OperandType {
 
     /// Memory barrier operation (ISB/DMB/DSB instructions)
     Barrier(Arm64BarrierOp),
+
+    /// SVCR operand for MSR SVCR instructions.
+    #[cfg(feature = "frida")]
+    Svcr,
+
+    /// SME instruction operand with with index.
+    #[cfg(feature = "frida")]
+    SmeIndex,
 
     /// Invalid
     Invalid,

--- a/capstone-sys/Cargo.toml
+++ b/capstone-sys/Cargo.toml
@@ -35,3 +35,4 @@ default = ["full"]
 full = []
 # use pre-generated bindings instead of dynamically with bindgen
 use_bindgen = ["bindgen", "regex"]  # Dynamically generate bindings with bindgen
+frida = ["use_bindgen"] # Clone frida's capstone fork from git instead of using upstream capstone


### PR DESCRIPTION
This adds the `frida` option that will clone the capstone fork from <https://github.com/frida/capstone>.
The changes in build.rs can be re-used for other forks in the future, as well.

Merging this does not have negative impact on the bindings, and will help us use them for frida.
See this issue for reference:
https://github.com/AFLplusplus/LibAFL/issues/1018

At some point the additions for the fork will need additional features that I'm not able to address, see added TODOs