### PR TITLE
[WIP] Compile-time Target Architecture Tags

### DIFF
--- a/capstone-rs/src/arch/arm.rs
+++ b/capstone-rs/src/arch/arm.rs
@@ -9,8 +9,10 @@ use capstone_sys::{
 use libc::c_uint;
 
 pub use crate::arch::arch_builder::arm::*;
-use crate::arch::DetailsArchInsn;
+use crate::arch::{ArchTag, DetailsArchInsn};
+use crate::arch::internal::ArchTagSealed;
 use crate::instruction::{RegId, RegIdInt};
+use crate::{Arch, InsnDetail};
 
 pub use capstone_sys::arm_insn_group as ArmInsnGroup;
 pub use capstone_sys::arm_insn as ArmInsn;
@@ -22,8 +24,36 @@ pub use capstone_sys::arm_cc as ArmCC;
 pub use capstone_sys::arm_mem_barrier as ArmMemBarrier;
 pub use capstone_sys::arm_setend_type as ArmSetendType;
 
+pub struct ArmArchTag;
+
+impl ArchTagSealed for ArmArchTag {}
+
+impl ArchTag for ArmArchTag {
+    type Builder = ArchCapstoneBuilder;
+
+    type Mode = ArchMode;
+    type ExtraMode = ArchExtraMode;
+    type Syntax = ArchSyntax;
+
+    type RegId = ArmReg::Type;
+    type InsnId = ArmInsn;
+    type InsnGroupId = ArmInsnGroup::Type;
+
+    type InsnDetail<'a> = ArmInsnDetail<'a>;
+
+    fn support_arch(arch: Arch) -> bool {
+        arch == Arch::ARM
+    }
+}
+
 /// Contains ARM-specific details for an instruction
 pub struct ArmInsnDetail<'a>(pub(crate) &'a cs_arm);
+
+impl<'a, 'i> From<&'i InsnDetail<'a, ArmArchTag>> for ArmInsnDetail<'a> {
+    fn from(value: &'i InsnDetail<'a, ArmArchTag>) -> Self {
+        Self(unsafe { &value.0.__bindgen_anon_1.arm })
+    }
+}
 
 /// ARM shift amount
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]

--- a/capstone-rs/src/arch/m680x.rs
+++ b/capstone-rs/src/arch/m680x.rs
@@ -12,9 +12,32 @@ pub use capstone_sys::m680x_insn as M680xInsn;
 pub use capstone_sys::m680x_reg as M680xReg;
 
 pub use crate::arch::arch_builder::m680x::*;
-use crate::arch::DetailsArchInsn;
+use crate::arch::{ArchTag, DetailsArchInsn};
+use crate::arch::internal::ArchTagSealed;
 use crate::instruction::{RegId, RegIdInt};
+use crate::{Arch, InsnDetail};
 
+pub struct M680xArchTag;
+
+impl ArchTagSealed for M680xArchTag {}
+
+impl ArchTag for M680xArchTag {
+    type Builder = ArchCapstoneBuilder;
+
+    type Mode = ArchMode;
+    type ExtraMode = ArchExtraMode;
+    type Syntax = ArchSyntax;
+
+    type RegId = M680xReg::Type;
+    type InsnId = M680xInsn;
+    type InsnGroupId = u32;
+
+    type InsnDetail<'a> = M680xInsnDetail<'a>;
+
+    fn support_arch(arch: Arch) -> bool {
+        arch == Arch::M680X
+    }
+}
 
 /// Contains M680X-specific details for an instruction
 pub struct M680xInsnDetail<'a>(pub(crate) &'a cs_m680x);
@@ -22,6 +45,12 @@ pub struct M680xInsnDetail<'a>(pub(crate) &'a cs_m680x);
 impl_PartialEq_repr_fields!(M680xInsnDetail<'a> [ 'a ];
     operands, flags
 );
+
+impl<'a, 'i> From<&'i InsnDetail<'a, M680xArchTag>> for M680xInsnDetail<'a> {
+    fn from(value: &'i InsnDetail<'a, M680xArchTag>) -> Self {
+        Self(unsafe { &value.0.__bindgen_anon_1.m680x })
+    }
+}
 
 // M680X instruction flags
 const M680X_FIRST_OP_IN_MNEM: u8 = 1;

--- a/capstone-rs/src/arch/mips.rs
+++ b/capstone-rs/src/arch/mips.rs
@@ -11,8 +11,32 @@ pub use capstone_sys::mips_insn as MipsInsn;
 pub use capstone_sys::mips_reg as MipsReg;
 
 pub use crate::arch::arch_builder::mips::*;
-use crate::arch::DetailsArchInsn;
+use crate::arch::{ArchTag, DetailsArchInsn};
+use crate::arch::internal::ArchTagSealed;
 use crate::instruction::{RegId, RegIdInt};
+use crate::{Arch, InsnDetail};
+
+pub struct MipsArchTag;
+
+impl ArchTagSealed for MipsArchTag {}
+
+impl ArchTag for MipsArchTag {
+    type Builder = ArchCapstoneBuilder;
+
+    type Mode = ArchMode;
+    type ExtraMode = ArchExtraMode;
+    type Syntax = ArchSyntax;
+
+    type RegId = MipsReg::Type;
+    type InsnId = MipsInsn;
+    type InsnGroupId = MipsInsnGroup::Type;
+
+    type InsnDetail<'a> = MipsInsnDetail<'a>;
+
+    fn support_arch(arch: Arch) -> bool {
+        arch == Arch::MIPS
+    }
+}
 
 /// Contains MIPS-specific details for an instruction
 pub struct MipsInsnDetail<'a>(pub(crate) &'a cs_mips);
@@ -20,6 +44,12 @@ pub struct MipsInsnDetail<'a>(pub(crate) &'a cs_mips);
 impl_PartialEq_repr_fields!(MipsInsnDetail<'a> [ 'a ];
     operands
 );
+
+impl<'a, 'i> From<&'i InsnDetail<'a, MipsArchTag>> for MipsInsnDetail<'a> {
+    fn from(value: &'i InsnDetail<'a, MipsArchTag>) -> Self {
+        Self(unsafe { &value.0.__bindgen_anon_1.mips })
+    }
+}
 
 /// MIPS operand
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/capstone-rs/src/arch/ppc.rs
+++ b/capstone-rs/src/arch/ppc.rs
@@ -12,8 +12,32 @@ pub use capstone_sys::ppc_bh as PpcBh;
 use capstone_sys::{cs_ppc, cs_ppc_op, ppc_op_mem, ppc_op_crx, ppc_op_type};
 
 pub use crate::arch::arch_builder::ppc::*;
-use crate::arch::DetailsArchInsn;
+use crate::arch::{ArchTag, DetailsArchInsn};
+use crate::arch::internal::ArchTagSealed;
 use crate::instruction::{RegId, RegIdInt};
+use crate::{Arch, InsnDetail};
+
+pub struct PpcArchTag;
+
+impl ArchTagSealed for PpcArchTag {}
+
+impl ArchTag for PpcArchTag {
+    type Builder = ArchCapstoneBuilder;
+
+    type Mode = ArchMode;
+    type ExtraMode = ArchExtraMode;
+    type Syntax = ArchSyntax;
+
+    type RegId = PpcReg::Type;
+    type InsnId = PpcInsn;
+    type InsnGroupId = PpcInsnGroup::Type;
+
+    type InsnDetail<'a> = PpcInsnDetail<'a>;
+
+    fn support_arch(arch: Arch) -> bool {
+        arch == Arch::PPC
+    }
+}
 
 /// Contains PPC-specific details for an instruction
 pub struct PpcInsnDetail<'a>(pub(crate) &'a cs_ppc);
@@ -38,6 +62,12 @@ impl<'a> PpcInsnDetail<'a> {
 impl_PartialEq_repr_fields!(PpcInsnDetail<'a> [ 'a ];
     bc, bh, update_cr0, operands
 );
+
+impl<'a, 'i> From<&'i InsnDetail<'a, PpcArchTag>> for PpcInsnDetail<'a> {
+    fn from(value: &'i InsnDetail<'a, PpcArchTag>) -> Self {
+        Self(unsafe { &value.0.__bindgen_anon_1.ppc })
+    }
+}
 
 /// PPC operand
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/capstone-rs/src/arch/riscv.rs
+++ b/capstone-rs/src/arch/riscv.rs
@@ -10,8 +10,32 @@ pub use capstone_sys::riscv_reg as RiscVReg;
 use capstone_sys::{cs_riscv, cs_riscv_op, riscv_op_mem, riscv_op_type};
 
 pub use crate::arch::arch_builder::riscv::*;
-use crate::arch::DetailsArchInsn;
+use crate::arch::{ArchTag, DetailsArchInsn};
+use crate::arch::internal::ArchTagSealed;
 use crate::instruction::{RegId, RegIdInt};
+use crate::{Arch, InsnDetail};
+
+pub struct RiscVArchTag;
+
+impl ArchTagSealed for RiscVArchTag {}
+
+impl ArchTag for RiscVArchTag {
+    type Builder = ArchCapstoneBuilder;
+
+    type Mode = ArchMode;
+    type ExtraMode = ArchExtraMode;
+    type Syntax = ArchSyntax;
+
+    type RegId = RiscVReg::Type;
+    type InsnId = RiscVInsn;
+    type InsnGroupId = RiscVInsnGroup::Type;
+
+    type InsnDetail<'a> = RiscVInsnDetail<'a>;
+
+    fn support_arch(arch: Arch) -> bool {
+        arch == Arch::RISCV
+    }
+}
 
 /// Contains RISCV-specific details for an instruction
 pub struct RiscVInsnDetail<'a>(pub(crate) &'a cs_riscv);
@@ -19,6 +43,12 @@ pub struct RiscVInsnDetail<'a>(pub(crate) &'a cs_riscv);
 impl_PartialEq_repr_fields!(RiscVInsnDetail<'a> [ 'a ];
     operands
 );
+
+impl<'a, 'i> From<&'i InsnDetail<'a, RiscVArchTag>> for RiscVInsnDetail<'a> {
+    fn from(value: &'i InsnDetail<'a, RiscVArchTag>) -> Self {
+        Self(unsafe { &value.0.__bindgen_anon_1.riscv })
+    }
+}
 
 /// RISCV operand
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/capstone-rs/src/arch/sparc.rs
+++ b/capstone-rs/src/arch/sparc.rs
@@ -12,12 +12,41 @@ pub use capstone_sys::sparc_hint as SparcHint;
 use capstone_sys::{cs_sparc, cs_sparc_op, sparc_op_mem, sparc_op_type};
 
 pub use crate::arch::arch_builder::sparc::*;
-use crate::arch::DetailsArchInsn;
+use crate::arch::{ArchTag, DetailsArchInsn};
+use crate::arch::internal::ArchTagSealed;
 use crate::instruction::{RegId, RegIdInt};
+use crate::{Arch, InsnDetail};
 
+pub struct SparcArchTag;
+
+impl ArchTagSealed for SparcArchTag {}
+
+impl ArchTag for SparcArchTag {
+    type Builder = ArchCapstoneBuilder;
+
+    type Mode = ArchMode;
+    type ExtraMode = ArchExtraMode;
+    type Syntax = ArchSyntax;
+
+    type RegId = SparcReg::Type;
+    type InsnId = SparcInsn;
+    type InsnGroupId = SparcInsnGroup::Type;
+
+    type InsnDetail<'a> = SparcInsnDetail<'a>;
+
+    fn support_arch(arch: Arch) -> bool {
+        arch == Arch::SPARC
+    }
+}
 
 /// Contains SPARC-specific details for an instruction
 pub struct SparcInsnDetail<'a>(pub(crate) &'a cs_sparc);
+
+impl<'a, 'i> From<&'i InsnDetail<'a, SparcArchTag>> for SparcInsnDetail<'a> {
+    fn from(value: &'i InsnDetail<'a, SparcArchTag>) -> Self {
+        Self(unsafe { &value.0.__bindgen_anon_1.sparc })
+    }
+}
 
 /// SPARC operand
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/capstone-rs/src/arch/sysz.rs
+++ b/capstone-rs/src/arch/sysz.rs
@@ -1,3 +1,42 @@
 //! Contains sysz-specific types
 
+pub use capstone_sys::sysz_insn_group as SyszInsnGroup;
+pub use capstone_sys::sysz_insn as SyszInsn;
+pub use capstone_sys::sysz_reg as SyszReg;
+use capstone_sys::cs_sysz;
+
 pub use crate::arch::arch_builder::sysz::*;
+use crate::arch::ArchTag;
+use crate::arch::internal::ArchTagSealed;
+use crate::{Arch, InsnDetail};
+
+pub struct SyszArchTag;
+
+impl ArchTagSealed for SyszArchTag {}
+
+impl ArchTag for SyszArchTag {
+    type Builder = ArchCapstoneBuilder;
+
+    type Mode = ArchMode;
+    type ExtraMode = ArchExtraMode;
+    type Syntax = ArchSyntax;
+
+    type RegId = SyszReg::Type;
+    type InsnId = SyszInsn;
+    type InsnGroupId = SyszInsnGroup::Type;
+
+    type InsnDetail<'a> = SyszInsnDetail<'a>;
+
+    fn support_arch(arch: Arch) -> bool {
+        arch == Arch::SYSZ
+    }
+}
+
+/// Contains sysz-specific details for an instruction
+pub struct SyszInsnDetail<'a>(pub(crate) &'a cs_sysz);
+
+impl<'a, 'i> From<&'i InsnDetail<'a, SyszArchTag>> for SyszInsnDetail<'a> {
+    fn from(value: &'i InsnDetail<'a, SyszArchTag>) -> Self {
+        Self(unsafe { &value.0.__bindgen_anon_1.sysz })
+    }
+}

--- a/capstone-rs/src/arch/tms320c64x.rs
+++ b/capstone-rs/src/arch/tms320c64x.rs
@@ -15,11 +15,41 @@ pub use capstone_sys::tms320c64x_insn_group as Tms320c64xInsnGroup;
 pub use capstone_sys::tms320c64x_reg as Tms320c64xReg;
 
 pub use crate::arch::arch_builder::tms320c64x::*;
+use crate::arch::ArchTag;
+use crate::arch::internal::ArchTagSealed;
 use crate::instruction::{RegId, RegIdInt};
+use crate::{Arch, InsnDetail};
 
+pub struct Tms320c64xArchTag;
+
+impl ArchTagSealed for Tms320c64xArchTag {}
+
+impl ArchTag for Tms320c64xArchTag {
+    type Builder = ArchCapstoneBuilder;
+
+    type Mode = ArchMode;
+    type ExtraMode = ArchExtraMode;
+    type Syntax = ArchSyntax;
+
+    type RegId = Tms320c64xReg::Type;
+    type InsnId = Tms320c64xInsn;
+    type InsnGroupId = Tms320c64xInsnGroup::Type;
+
+    type InsnDetail<'a> = Tms320c64xInsnDetail<'a>;
+
+    fn support_arch(arch: Arch) -> bool {
+        arch == Arch::TMS320C64X
+    }
+}
 
 /// Contains TMS320C64X-specific details for an instruction
 pub struct Tms320c64xInsnDetail<'a>(pub(crate) &'a cs_tms320c64x);
+
+impl<'a, 'i> From<&'i InsnDetail<'a, Tms320c64xArchTag>> for Tms320c64xInsnDetail<'a> {
+    fn from(value: &'i InsnDetail<'a, Tms320c64xArchTag>) -> Self {
+        Self(unsafe { &value.0.__bindgen_anon_1.tms320c64x })
+    }
+}
 
 define_cs_enum_wrapper_reverse!(
     [

--- a/capstone-rs/src/arch/x86.rs
+++ b/capstone-rs/src/arch/x86.rs
@@ -18,11 +18,41 @@ pub use capstone_sys::x86_xop_cc as X86XopCC;
 pub use capstone_sys::x86_avx_rm as X86AvxRm;
 
 pub use crate::arch::arch_builder::x86::*;
-use crate::arch::DetailsArchInsn;
+use crate::arch::{ArchTag, DetailsArchInsn};
+use crate::arch::internal::ArchTagSealed;
 use crate::instruction::{RegAccessType, RegId, RegIdInt};
+use crate::{Arch, InsnDetail};
+
+pub struct X86ArchTag;
+
+impl ArchTagSealed for X86ArchTag {}
+
+impl ArchTag for X86ArchTag {
+    type Builder = ArchCapstoneBuilder;
+
+    type Mode = ArchMode;
+    type ExtraMode = ArchExtraMode;
+    type Syntax = ArchSyntax;
+
+    type RegId = X86Reg::Type;
+    type InsnId = X86Insn;
+    type InsnGroupId = X86InsnGroup::Type;
+
+    type InsnDetail<'a> = X86InsnDetail<'a>;
+
+    fn support_arch(arch: Arch) -> bool {
+        arch == Arch::X86
+    }
+}
 
 /// Contains X86-specific details for an instruction
 pub struct X86InsnDetail<'a>(pub(crate) &'a cs_x86);
+
+impl<'a, 'i> From<&'i InsnDetail<'a, X86ArchTag>> for X86InsnDetail<'a> {
+    fn from(value: &'i InsnDetail<'a, X86ArchTag>) -> Self {
+        Self(unsafe { &value.0.__bindgen_anon_1.x86 })
+    }
+}
 
 // todo(tmfink): expose new types cs_x86__bindgen_ty_1, cs_x86_encoding, x86_xop_cc,
 // cs_x86_op::access

--- a/capstone-rs/src/arch/xcore.rs
+++ b/capstone-rs/src/arch/xcore.rs
@@ -10,8 +10,32 @@ pub use capstone_sys::xcore_reg as XcoreReg;
 use capstone_sys::{cs_xcore, cs_xcore_op, xcore_op_mem, xcore_op_type};
 
 pub use crate::arch::arch_builder::xcore::*;
-use crate::arch::DetailsArchInsn;
+use crate::arch::{ArchTag, DetailsArchInsn};
+use crate::arch::internal::ArchTagSealed;
 use crate::instruction::{RegId, RegIdInt};
+use crate::{Arch, InsnDetail};
+
+pub struct XcoreArchTag;
+
+impl ArchTagSealed for XcoreArchTag {}
+
+impl ArchTag for XcoreArchTag {
+    type Builder = ArchCapstoneBuilder;
+
+    type Mode = ArchMode;
+    type ExtraMode = ArchExtraMode;
+    type Syntax = ArchSyntax;
+
+    type RegId = XcoreReg::Type;
+    type InsnId = XcoreInsn;
+    type InsnGroupId = XcoreInsnGroup::Type;
+
+    type InsnDetail<'a> = XcoreInsnDetail<'a>;
+
+    fn support_arch(arch: Arch) -> bool {
+        arch == Arch::XCORE
+    }
+}
 
 /// Contains XCORE-specific details for an instruction
 pub struct XcoreInsnDetail<'a>(pub(crate) &'a cs_xcore);
@@ -19,6 +43,12 @@ pub struct XcoreInsnDetail<'a>(pub(crate) &'a cs_xcore);
 impl_PartialEq_repr_fields!(XcoreInsnDetail<'a> [ 'a ];
     operands
 );
+
+impl<'a, 'i> From<&'i InsnDetail<'a, XcoreArchTag>> for XcoreInsnDetail<'a> {
+    fn from(value: &'i InsnDetail<'a, XcoreArchTag>) -> Self {
+        Self(unsafe { &value.0.__bindgen_anon_1.xcore })
+    }
+}
 
 /// XCORE operand
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
This PR resolves #118, which proposes **compile-time target architecture tags**. It contains a series of commits that implement the proposal. Problems may arise as I author these commits so I'm opening this PR in an early stage to make sure that we can agree on the specific designs in the end.

Here's a list of unresolved problems:
- [ ] Currently, there is no `CapstoneBuilder` that builds `Capstone` instances whose target architectures are "really" unknown at compile-time. When we call functions like `x86`, we have explicitly tell that the target architecture is `x86`. We should implement a new builder that sets the target architecture via a runtime `Arch` value.
- [ ] Currently, for many supported architectures, their `RegId` and `InsnGroupId` (some architectures even the `InsnId`) are simply defined as a bunch of `u32` values inside a mod rather than a dedicated enum (e.g. ARM, ARM64, x86, etc.). We’d better re-define them to be dedicated enums so that defining `ArchTag::RegId` and `ArchTag::InsnGroupId` is meaningful.
- [ ] After we support compile-time arch tags, many operations need not to return an `Option` or `Result` any more as they should always succeed given the exact target architecture. But for `DynamicArchTag` these operations may still fail so we need to keep their return types as it is now. How do we resolve the conflict?