### PR TITLE
Regs access

### DIFF
--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -388,16 +388,15 @@ impl Capstone {
                     return Some(Err(err.into()));
                 }
 
-                assert!(regs_read_count as usize <= regs_read.len());
-                assert!(regs_write_count as usize <= regs_write.len());
+                fn to_vec(ints: [u16; 64], len: usize) -> Vec<RegId> {
+                    assert!(len <= ints.len());
+                    ints[..len].iter().map(|v| RegId(*v)).collect()
+                }
 
-                let regs_write: Vec<_> = regs_write[..regs_write_count as usize]
-                    .iter()
-                    .map(|v| RegId(*v))
-                    .collect();
-                let regs_read = regs_write[..regs_write_count as usize].to_vec();
-
-                (regs_write, regs_read)
+                (
+                    to_vec(regs_read, regs_read_count as usize),
+                    to_vec(regs_write, regs_write_count as usize),
+                )
             };
 
             Some(Ok((read, write)))

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -378,7 +378,8 @@ impl Capstone {
         Ok((read, write))
     }
 
-    /// Get the registers are which are read to and written to, in that order.
+    /// Get the registers are which are read to and written to\
+    /// the registers are pushed to the back of the provided buffers
     pub fn regs_access(
         &self,
         insn: &Insn,

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -103,6 +103,11 @@ impl Iterator for EmptyExtraModeIter {
     }
 }
 
+pub struct RegAccess {
+    pub read: Vec<RegId>,
+    pub write: Vec<RegId>,
+}
+
 impl Capstone {
     /// Create a new instance of the decompiler using the builder pattern interface.
     /// This is the recommended interface to `Capstone`.
@@ -369,13 +374,13 @@ impl Capstone {
     }
 
     /// Get the registers are which are read to and written to
-    pub fn regs_access_buf(&self, insn: &Insn) -> CsResult<(Vec<RegId>, Vec<RegId>)> {
+    pub fn regs_access_buf(&self, insn: &Insn) -> CsResult<RegAccess> {
         let mut read = Vec::new();
         let mut write = Vec::new();
 
         self.regs_access(insn, &mut read, &mut write)?;
 
-        Ok((read, write))
+        Ok(RegAccess { read, write })
     }
 
     /// Get the registers are which are read to and written to\

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -368,7 +368,7 @@ impl Capstone {
     /// Get the registers are which are read to and written to, in that order.
     pub fn regs_access(&self, insn: &Insn) -> Option<CsResult<(Vec<RegId>, Vec<RegId>)>> {
         if cfg!(feature = "full") {
-            let (write, read) = unsafe {
+            Some(Ok(unsafe {
                 let mut regs_read_count: u8 = 0;
                 let mut regs_write_count: u8 = 0;
 
@@ -397,9 +397,7 @@ impl Capstone {
                     to_vec(regs_read, regs_read_count as usize),
                     to_vec(regs_write, regs_write_count as usize),
                 )
-            };
-
-            Some(Ok((read, write)))
+            }))
         } else {
             None
         }

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -14,6 +14,9 @@ use crate::instruction::{Insn, InsnDetail, InsnGroupId, InsnId, Instructions, Re
 
 use {crate::ffi::str_from_cstr_ptr, alloc::string::ToString, libc::c_uint};
 
+/// This is taken from the [python bindings](https://github.com/capstone-engine/capstone/blob/5fb8a423d4455cade99b12912142fd3a0c10d957/bindings/python/capstone/__init__.py#L929)
+const MAX_NUM_REGISTERS: usize = 64;
+
 /// An instance of the capstone disassembler
 ///
 /// Create with an instance with [`.new()`](Self::new) and disassemble bytes with [`.disasm_all()`](Self::disasm_all).
@@ -372,8 +375,8 @@ impl Capstone {
                 let mut regs_read_count: u8 = 0;
                 let mut regs_write_count: u8 = 0;
 
-                let mut regs_write = [0u16; 64];
-                let mut regs_read = [0u16; 64];
+                let mut regs_write = [0u16; MAX_NUM_REGISTERS];
+                let mut regs_read = [0u16; MAX_NUM_REGISTERS];
 
                 let err = cs_regs_access(
                     self.csh(),
@@ -388,7 +391,7 @@ impl Capstone {
                     return Err(err.into());
                 }
 
-                fn to_vec(ints: [u16; 64], len: usize) -> Vec<RegId> {
+                fn to_vec(ints: [u16; MAX_NUM_REGISTERS], len: usize) -> Vec<RegId> {
                     assert!(len <= ints.len());
                     ints[..len].iter().map(|v| RegId(*v)).collect()
                 }

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -366,9 +366,9 @@ impl Capstone {
     }
 
     /// Get the registers are which are read to and written to, in that order.
-    pub fn regs_access(&self, insn: &Insn) -> Option<CsResult<(Vec<RegId>, Vec<RegId>)>> {
+    pub fn regs_access(&self, insn: &Insn) -> CsResult<(Vec<RegId>, Vec<RegId>)> {
         if cfg!(feature = "full") {
-            Some(Ok(unsafe {
+            Ok(unsafe {
                 let mut regs_read_count: u8 = 0;
                 let mut regs_write_count: u8 = 0;
 
@@ -385,7 +385,7 @@ impl Capstone {
                 );
 
                 if err != cs_err::CS_ERR_OK {
-                    return Some(Err(err.into()));
+                    return Err(err.into());
                 }
 
                 fn to_vec(ints: [u16; 64], len: usize) -> Vec<RegId> {
@@ -397,9 +397,9 @@ impl Capstone {
                     to_vec(regs_read, regs_read_count as usize),
                     to_vec(regs_write, regs_write_count as usize),
                 )
-            }))
+            })
         } else {
-            None
+            Err(Error::DetailOff)
         }
     }
 

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -366,7 +366,7 @@ impl Capstone {
     }
 
     /// Get the registers are which are read to and written to, in that order.
-    pub fn regs_access(&self, insn: Insn) -> Option<CsResult<(Vec<RegId>, Vec<RegId>)>> {
+    pub fn regs_access(&self, insn: &Insn) -> Option<CsResult<(Vec<RegId>, Vec<RegId>)>> {
         if cfg!(feature = "full") {
             let (write, read) = unsafe {
                 let mut regs_read_count: u8 = 0;

--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -386,39 +386,41 @@ impl Capstone {
         write: &mut Vec<RegId>,
     ) -> CsResult<()> {
         if cfg!(feature = "full") {
-            Ok(unsafe {
-                let mut regs_read_count: u8 = 0;
-                let mut regs_write_count: u8 = 0;
+            let mut regs_read_count: u8 = 0;
+            let mut regs_write_count: u8 = 0;
 
-                let mut regs_write = [0u16; MAX_NUM_REGISTERS];
-                let mut regs_read = [0u16; MAX_NUM_REGISTERS];
+            let mut regs_write = [0u16; MAX_NUM_REGISTERS];
+            let mut regs_read = [0u16; MAX_NUM_REGISTERS];
 
-                let err = cs_regs_access(
+            let err = unsafe {
+                cs_regs_access(
                     self.csh(),
                     &insn.insn as *const cs_insn,
                     &mut regs_read as *mut _,
                     &mut regs_read_count as *mut _,
                     &mut regs_write as *mut _,
                     &mut regs_write_count as *mut _,
-                );
+                )
+            };
 
-                if err != cs_err::CS_ERR_OK {
-                    return Err(err.into());
-                }
+            if err != cs_err::CS_ERR_OK {
+                return Err(err.into());
+            }
 
-                read.extend(
-                    regs_read
-                        .iter()
-                        .take(regs_read_count as usize)
-                        .map(|x| RegId(*x)),
-                );
-                write.extend(
-                    regs_write
-                        .iter()
-                        .take(regs_write_count as usize)
-                        .map(|x| RegId(*x)),
-                );
-            })
+            read.extend(
+                regs_read
+                    .iter()
+                    .take(regs_read_count as usize)
+                    .map(|x| RegId(*x)),
+            );
+            write.extend(
+                regs_write
+                    .iter()
+                    .take(regs_write_count as usize)
+                    .map(|x| RegId(*x)),
+            );
+
+            Ok(())
         } else {
             Err(Error::DetailOff)
         }


### PR DESCRIPTION
I think the if cfg! is kinda weird and should probably rather have it just gate the entire function instead? Anyway, I'm not sure how to handle `assert!(len <= ints.len());` better, but it should never happen anyway so it probably doesn't matter?

Also I just picked 64 because python uses that, though I have a hard time imagining reading/writing to more than 64 registers: https://github.com/capstone-engine/capstone/blob/5fb8a423d4455cade99b12912142fd3a0c10d957/bindings/python/capstone/__init__.py#L929

