### PR TITLE
Fix cs_support enum bug

### DIFF
--- a/capstone-rs/src/capstone.rs
+++ b/capstone-rs/src/capstone.rs
@@ -412,7 +412,7 @@ impl Capstone {
 
     /// Returns whether the capstone library supports a given architecture.
     pub fn supports_arch(arch: Arch) -> bool {
-        unsafe { cs_support(arch as c_int) }
+        unsafe { cs_support(cs_arch::from(arch) as c_int) }
     }
 
     /// Returns whether the capstone library was compiled in diet mode.


### PR DESCRIPTION
The enum `capstone::Arch` doesn't have the same values as capstone's `cs_arch` enum. This causes calls to `supports_arch()` to return incorrect results once the enum values diverge, which happens for riscv and a few others.

Fortunately, `capstone_sys::cs_arch` has a `From<capstone::Arch>` implementation, so we can just use that to do the correct conversion.