### PR TITLE
Implement InsnDetail (+ associated types) for sysz

### DIFF
--- a/capstone-rs/src/arch/mod.rs
+++ b/capstone-rs/src/arch/mod.rs
@@ -551,6 +551,13 @@ macro_rules! detail_arch_base {
                 /// Returns the BPF details, if any
                 => arch_name = bpf,
             ]
+            [
+                detail = SysZDetail,
+                insn_detail = SysZInsnDetail<'a>,
+                op = SysZOperand,
+                /// Returns the SysZ details, if any
+                => arch_name = sysz,
+            ]
         );
     };
 }

--- a/capstone-rs/src/arch/sysz.rs
+++ b/capstone-rs/src/arch/sysz.rs
@@ -1,3 +1,106 @@
 //! Contains sysz-specific types
 
+use core::convert::From;
+use core::{cmp, fmt, slice};
+
+// XXX todo(garnt): create rusty versions
+pub use capstone_sys::sysz_insn_group as SysZInsnGroup;
+pub use capstone_sys::sysz_insn as SysZInsn;
+pub use capstone_sys::sysz_reg as SysZReg;
+use capstone_sys::{cs_sysz, cs_sysz_op, sysz_op_mem, sysz_op_type};
+
 pub use crate::arch::arch_builder::sysz::*;
+use crate::arch::DetailsArchInsn;
+use crate::instruction::{RegId, RegIdInt};
+
+/// Contains sysz-specific details for an instruction
+pub struct SysZInsnDetail<'a>(pub(crate) &'a cs_sysz);
+
+impl_PartialEq_repr_fields!(SysZInsnDetail<'a> [ 'a ];
+    operands
+);
+
+/// SysZ operand
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SysZOperand {
+    /// Register
+    Reg(RegId),
+
+    /// Immediate
+    Imm(i64),
+
+    /// Memory
+    Mem(SysZOpMem),
+
+    /// Access Register
+    AcReg(RegId),
+
+    /// Invalid
+    Invalid,
+}
+
+impl Default for SysZOperand {
+    fn default() -> Self {
+        SysZOperand::Invalid
+    }
+}
+
+/// SysZ memory operand
+#[derive(Debug, Copy, Clone)]
+pub struct SysZOpMem(pub(crate) sysz_op_mem);
+
+impl SysZOpMem {
+    /// Base register
+    pub fn base(&self) -> u8 {
+        self.0.base
+    }
+
+    /// Index register
+    pub fn index(&self) -> u8 {
+        self.0.index
+    }
+
+    /// BDLAddr operand
+    pub fn length(&self) -> u64 {
+        self.0.length
+    }
+
+    /// Disp value
+    pub fn disp(&self) -> i64 {
+        self.0.disp
+    }
+}
+
+impl_PartialEq_repr_fields!(SysZOpMem;
+    base, index, length, disp
+);
+
+impl cmp::Eq for SysZOpMem {}
+
+impl <'a> From<&'a cs_sysz_op> for SysZOperand {
+    fn from(insn: &cs_sysz_op) -> SysZOperand {
+        match insn.type_ {
+            sysz_op_type::SYSZ_OP_REG => {
+                SysZOperand::Reg(RegId(unsafe { insn.__bindgen_anon_1.reg } as RegIdInt))
+            },
+            sysz_op_type::SYSZ_OP_IMM => SysZOperand::Imm(unsafe { insn.__bindgen_anon_1.imm }),
+            sysz_op_type::SYSZ_OP_MEM => {
+                SysZOperand::Mem(SysZOpMem(unsafe { insn.__bindgen_anon_1.mem }))
+            },
+            sysz_op_type::SYSZ_OP_ACREG => {
+                SysZOperand::AcReg(RegId(unsafe { insn.__bindgen_anon_1.reg } as RegIdInt))
+            },
+            sysz_op_type::SYSZ_OP_INVALID => SysZOperand::Invalid,
+        }
+    }
+}
+
+def_arch_details_struct!(
+    InsnDetail = SysZInsnDetail;
+    Operand = SysZOperand;
+    OperandIterator = SysZOperandIterator;
+    OperandIteratorLife = SysZOperandIterator<'a>;
+    [ pub struct SysZOperandIterator<'a>(slice::Iter<'a, cs_sysz_op>); ]
+    cs_arch_op = cs_sysz_op;
+    cs_arch = cs_sysz;
+);

--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -413,6 +413,7 @@ impl<'a> InsnDetail<'a> {
                             $detail($insn_detail(unsafe { &self.0.__bindgen_anon_1.$arch }))
                         }
                     )*
+                    #[allow(unreachable_patterns)]
                     _ => panic!("Unsupported detail arch"),
                 }
             }
@@ -431,6 +432,7 @@ impl<'a> InsnDetail<'a> {
             [X86, X86Detail, X86InsnDetail, x86]
             [XCORE, XcoreDetail, XcoreInsnDetail, xcore]
             [BPF, BpfDetail, BpfInsnDetail, bpf]
+            [SYSZ, SysZDetail, SysZInsnDetail, sysz]
         );
     }
 }

--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -413,8 +413,6 @@ impl<'a> InsnDetail<'a> {
                             $detail($insn_detail(unsafe { &self.0.__bindgen_anon_1.$arch }))
                         }
                     )*
-                    #[allow(unreachable_patterns)]
-                    _ => panic!("Unsupported detail arch"),
                 }
             }
         }

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -2492,6 +2492,65 @@ fn test_arch_systemz() {
 }
 
 #[test]
+fn test_arch_systemz_detail() {
+    use crate::arch::sysz::SysZOperand::*;
+    use crate::arch::sysz::SysZReg::*;
+    use crate::arch::sysz::*;
+    use capstone_sys::sysz_op_mem;
+
+    test_arch_mode_endian_insns_detail(
+        &mut Capstone::new()
+            .sysz()
+            .mode(sysz::ArchMode::Default)
+            .build()
+            .unwrap(),
+        Arch::SYSZ,
+        Mode::Default,
+        None,
+        &[],
+        &[
+            // br %r7
+            DII::new("br", b"\x07\xf7", &[Reg(RegId(SYSZ_REG_7 as RegIdInt))]),
+            // ear %r7, %a8
+            DII::new(
+                "ear",
+                b"\xb2\x4f\x00\x78",
+                &[
+                    Reg(RegId(SYSZ_REG_7 as RegIdInt)),
+                    Reg(RegId(SYSZ_REG_A8 as RegIdInt)),
+                ],
+            ),
+            // adb %f0, 0
+            DII::new(
+                "adb",
+                b"\xed\x00\x00\x00\x00\x1a",
+                &[Reg(RegId(SYSZ_REG_F0 as RegIdInt)), Imm(0)],
+            ),
+            // afi %r0, -0x80000000
+            DII::new(
+                "afi",
+                b"\xc2\x09\x80\x00\x00\x00",
+                &[Reg(RegId(SYSZ_REG_0 as RegIdInt)), Imm(-0x80000000)],
+            ),
+            // a %r0, 0xfff(%r15, %r1)
+            DII::new(
+                "a",
+                b"\x5a\x0f\x1f\xff",
+                &[
+                    Reg(RegId(SYSZ_REG_0 as RegIdInt)),
+                    Mem(SysZOpMem(sysz_op_mem {
+                        base: SYSZ_REG_1 as u8,
+                        index: SYSZ_REG_15 as u8,
+                        disp: 0xfff,
+                        length: 0,
+                    })),
+                ],
+            ),
+        ],
+    );
+}
+
+#[test]
 fn test_arch_tms320c64x_detail() {
     use crate::arch::tms320c64x::{
         Tms320c64xFuntionalUnit, Tms320c64xMemDirection, Tms320c64xMemDisplayType,


### PR DESCRIPTION
This PR implements `InsnDetail`, `SysZOperand`, etc.  to enable instruction details for sysz. I used the RISC-V implementation as a template, so the code style should follow the rest of the library's conventions.