### PR TITLE
Implementing Clone for the Insn and cs_insn Structures

### DIFF
--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -167,6 +167,15 @@ pub struct Insn<'a> {
     pub(crate) _marker: PhantomData<&'a InsnDetail<'a>>,
 }
 
+impl<'a> Clone for Insn<'a> {
+    fn clone(&self) -> Self {
+        Self {
+            insn: self.insn.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
 /// Contains architecture-independent details about an [`Insn`].
 ///
 /// To get more detail about the instruction, enable extra details for the

--- a/capstone-sys/pre_generated/capstone.rs
+++ b/capstone-sys/pre_generated/capstone.rs
@@ -15715,6 +15715,21 @@ pub struct cs_insn {
     #[doc = " Pointer to cs_detail.\n NOTE: detail pointer is only valid when both requirements below are met:\n (1) CS_OP_DETAIL = CS_OPT_ON\n (2) Engine is not in Skipdata mode (CS_OP_SKIPDATA option set to CS_OPT_ON)\n\n NOTE 2: when in Skipdata mode, or when detail mode is OFF, even if this pointer\n     is not NULL, its content is still irrelevant."]
     pub detail: *mut cs_detail,
 }
+
+impl Clone for cs_insn {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            address: self.address,
+            size: self.size,
+            bytes: self.bytes,
+            mnemonic: self.mnemonic,
+            op_str: self.op_str,
+            detail: self.detail.clone(),
+        }
+    }
+}
+
 impl ::core::fmt::Debug for cs_insn {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(


### PR DESCRIPTION
Typically, when writing more complex code using `capstone` we can collect `cs_insn` structures on their own.

For example, we can create a list of `cs_insn` structures in Python without them going out of scope.

Currently this is not appearing to be possible in `capstone-rs`  because the `Insn` and `cs_insn` structures only being accessed by reference when contained in `Instructions` iterator.

Most of the work on implementing the `clone` functionality has already been done for `cs_detail` structure and others.

This PR simply implements `clone` for both `cs_insn` and `Insn` structures, so it is possible to store these for later use in more complex projects.

Here is an example of using this functionality:
```rs
pub fn disassemble_instruction(&self, address: u64) -> Result<Insn, Error> {
        let instructions = match self.disassemble_instructions(address, 1) {
            Ok(instructions) => instructions,
            Err(error) => return Err(Error::new(ErrorKind::Other, "failed to disassemble instruction")),
        };
        let instruction: Insn<'_> = instructions.iter().next().unwrap().clone();
        return Ok(instruction);
    }
```

It also helps for when we need to iterate a single instruction at a time collecting them for later post-processing.

This becomes an issue when having to unpack from the `Instructions` iterator and only getting references without the possibility of cloning for later use.

This should not break any other features, it simply continues what was already done with `cs_detail` and other places `clone` has already been implemented in the `capstone-rs` project.

That being said, this is my first Rust-based PR, so proceed with caution.

Thank you :smile: 

