### PR TITLE
Fix segfault in cs_option() on s390x

### DIFF
--- a/capstone-rs/src/arch/arm.rs
+++ b/capstone-rs/src/arch/arm.rs
@@ -171,7 +171,7 @@ pub enum ArmOperandType {
 #[derive(Debug, Copy, Clone)]
 pub struct ArmOpMem(pub(crate) arm_op_mem);
 
-impl<'a> ArmInsnDetail<'a> {
+impl ArmInsnDetail<'_> {
     /// Whether the instruction is a user mode
     pub fn usermode(&self) -> bool {
         self.0.usermode
@@ -263,7 +263,7 @@ impl Default for ArmOperand {
     }
 }
 
-impl<'a> From<&'a cs_arm_op> for ArmOperand {
+impl From<&cs_arm_op> for ArmOperand {
     fn from(op: &cs_arm_op) -> ArmOperand {
         let shift = ArmShift::new(op.shift.type_, op.shift.value);
         let op_type = ArmOperandType::new(op.type_, op.__bindgen_anon_1);

--- a/capstone-rs/src/arch/arm64.rs
+++ b/capstone-rs/src/arch/arm64.rs
@@ -139,7 +139,7 @@ pub enum Arm64OperandType {
 #[derive(Debug, Copy, Clone)]
 pub struct Arm64OpMem(pub(crate) arm64_op_mem);
 
-impl<'a> Arm64InsnDetail<'a> {
+impl Arm64InsnDetail<'_> {
     /// Condition codes
     pub fn cc(&self) -> Arm64CC {
         self.0.cc
@@ -224,7 +224,7 @@ impl Arm64Shift {
     }
 }
 
-impl<'a> From<&'a cs_arm64_op> for Arm64Operand {
+impl From<&cs_arm64_op> for Arm64Operand {
     fn from(op: &cs_arm64_op) -> Arm64Operand {
         let shift = Arm64Shift::new(op.shift.type_, op.shift.value);
         let op_type = Arm64OperandType::new(op.type_, op.__bindgen_anon_1);

--- a/capstone-rs/src/arch/bpf.rs
+++ b/capstone-rs/src/arch/bpf.rs
@@ -76,7 +76,7 @@ impl_PartialEq_repr_fields!(BpfOpMem;
 
 impl cmp::Eq for BpfOpMem {}
 
-impl<'a> From<&'a cs_bpf_op> for BpfOperand {
+impl From<&cs_bpf_op> for BpfOperand {
     fn from(insn: &cs_bpf_op) -> BpfOperand {
         match insn.type_ {
             bpf_op_type::BPF_OP_EXT => BpfOperand::Ext(unsafe { insn.__bindgen_anon_1.ext }),

--- a/capstone-rs/src/arch/evm.rs
+++ b/capstone-rs/src/arch/evm.rs
@@ -14,7 +14,7 @@ use crate::arch::DetailsArchInsn;
 /// Contains EVM-specific details for an instruction
 pub struct EvmInsnDetail<'a>(pub(crate) &'a cs_evm);
 
-impl<'a> EvmInsnDetail<'a> {
+impl EvmInsnDetail<'_> {
     /// Number of items popped from the stack
     pub fn popped_items(&self) -> u8 {
         self.0.pop
@@ -77,7 +77,7 @@ impl fmt::Debug for EvmOperandIterator {
     }
 }
 
-impl<'a> fmt::Debug for EvmInsnDetail<'a> {
+impl fmt::Debug for EvmInsnDetail<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> ::core::fmt::Result {
         fmt.debug_struct("EvmInsnDetail")
             .field("cs_evm", &(self.0 as *const cs_evm))
@@ -85,7 +85,7 @@ impl<'a> fmt::Debug for EvmInsnDetail<'a> {
     }
 }
 
-impl<'a> DetailsArchInsn for EvmInsnDetail<'a> {
+impl DetailsArchInsn for EvmInsnDetail<'_> {
     type OperandIterator = EvmOperandIterator;
     type Operand = EvmOperand;
 

--- a/capstone-rs/src/arch/m680x.rs
+++ b/capstone-rs/src/arch/m680x.rs
@@ -181,7 +181,7 @@ impl Default for M680xOperandType {
     }
 }
 
-impl<'a> From<&'a cs_m680x_op> for M680xOperand {
+impl From<&cs_m680x_op> for M680xOperand {
     fn from(op: &cs_m680x_op) -> M680xOperand {
         let op_type = match op.type_ {
             m680x_op_type::M680X_OP_REGISTER => {

--- a/capstone-rs/src/arch/m68k.rs
+++ b/capstone-rs/src/arch/m68k.rs
@@ -23,7 +23,7 @@ use crate::prelude::*;
 /// Contains M68K-specific details for an instruction
 pub struct M68kInsnDetail<'a>(pub(crate) &'a cs_m68k);
 
-impl<'a> M68kInsnDetail<'a> {
+impl M68kInsnDetail<'_> {
     /// size of data operand works on in bytes (.b, .w, .l, etc)
     pub fn op_size(&self) -> Option<M68kOpSize> {
         M68kOpSize::new(&self.0.op_size)
@@ -444,7 +444,7 @@ impl_PartialEq_repr_fields!(M68kOpMem;
 
 impl cmp::Eq for M68kOpMem {}
 
-impl<'a> From<&'a cs_m68k_op> for M68kOperand {
+impl From<&cs_m68k_op> for M68kOperand {
     fn from(insn: &cs_m68k_op) -> M68kOperand {
         M68kOperand::new(insn)
     }

--- a/capstone-rs/src/arch/mips.rs
+++ b/capstone-rs/src/arch/mips.rs
@@ -65,7 +65,7 @@ impl_PartialEq_repr_fields!(MipsOpMem;
 
 impl cmp::Eq for MipsOpMem {}
 
-impl<'a> From<&'a cs_mips_op> for MipsOperand {
+impl From<&cs_mips_op> for MipsOperand {
     fn from(insn: &cs_mips_op) -> MipsOperand {
         match insn.type_ {
             mips_op_type::MIPS_OP_REG => {

--- a/capstone-rs/src/arch/mod.rs
+++ b/capstone-rs/src/arch/mod.rs
@@ -610,7 +610,7 @@ macro_rules! detail_defs {
 
             $(
                 $( #[$func_attr] )+
-                pub fn $arch_name(&'a self) -> Option<& $InsnDetail> {
+                pub fn $arch_name(&'a self) -> Option<&'a $InsnDetail> {
                     if let ArchDetail::$Detail(ref arch_detail) = *self {
                         Some(arch_detail)
                     } else {

--- a/capstone-rs/src/arch/ppc.rs
+++ b/capstone-rs/src/arch/ppc.rs
@@ -18,7 +18,7 @@ use crate::instruction::{RegId, RegIdInt};
 /// Contains PPC-specific details for an instruction
 pub struct PpcInsnDetail<'a>(pub(crate) &'a cs_ppc);
 
-impl<'a> PpcInsnDetail<'a> {
+impl PpcInsnDetail<'_> {
     /// Branch code for branch instructions
     pub fn bc(&self) -> PpcBc {
         self.0.bc
@@ -115,7 +115,7 @@ impl cmp::PartialEq for PpcOpCrx {
 
 impl cmp::Eq for PpcOpCrx {}
 
-impl<'a> From<&'a cs_ppc_op> for PpcOperand {
+impl From<&cs_ppc_op> for PpcOperand {
     fn from(insn: &cs_ppc_op) -> PpcOperand {
         match insn.type_ {
             ppc_op_type::PPC_OP_REG => {

--- a/capstone-rs/src/arch/riscv.rs
+++ b/capstone-rs/src/arch/riscv.rs
@@ -64,7 +64,7 @@ impl_PartialEq_repr_fields!(RiscVOpMem;
 
 impl cmp::Eq for RiscVOpMem {}
 
-impl<'a> From<&'a cs_riscv_op> for RiscVOperand {
+impl From<&cs_riscv_op> for RiscVOperand {
     fn from(insn: &cs_riscv_op) -> RiscVOperand {
         match insn.type_ {
             riscv_op_type::RISCV_OP_REG => {

--- a/capstone-rs/src/arch/sparc.rs
+++ b/capstone-rs/src/arch/sparc.rs
@@ -35,7 +35,7 @@ pub enum SparcOperand {
     Invalid,
 }
 
-impl<'a> SparcInsnDetail<'a> {
+impl SparcInsnDetail<'_> {
     /// Condition codes
     pub fn cc(&self) -> SparcCC {
         self.0.cc
@@ -84,7 +84,7 @@ impl_PartialEq_repr_fields!(SparcOpMem;
 
 impl cmp::Eq for SparcOpMem {}
 
-impl<'a> From<&'a cs_sparc_op> for SparcOperand {
+impl From<&cs_sparc_op> for SparcOperand {
     fn from(insn: &cs_sparc_op) -> SparcOperand {
         match insn.type_ {
             sparc_op_type::SPARC_OP_REG => {

--- a/capstone-rs/src/arch/sysz.rs
+++ b/capstone-rs/src/arch/sysz.rs
@@ -77,7 +77,7 @@ impl_PartialEq_repr_fields!(SysZOpMem;
 
 impl cmp::Eq for SysZOpMem {}
 
-impl <'a> From<&'a cs_sysz_op> for SysZOperand {
+impl  From<&cs_sysz_op> for SysZOperand {
     fn from(insn: &cs_sysz_op) -> SysZOperand {
         match insn.type_ {
             sysz_op_type::SYSZ_OP_REG => {

--- a/capstone-rs/src/arch/tms320c64x.rs
+++ b/capstone-rs/src/arch/tms320c64x.rs
@@ -40,7 +40,7 @@ define_cs_enum_wrapper_reverse!(
     => No = TMS320C64X_FUNIT_NO;
 );
 
-impl<'a> Tms320c64xInsnDetail<'a> {
+impl Tms320c64xInsnDetail<'_> {
     /// Whether condition is zero
     pub fn is_condition_zero(&self) -> bool {
         self.0.condition.zero != 0
@@ -220,7 +220,7 @@ impl_PartialEq_repr_fields!(Tms320c64xOpMem;
 
 impl cmp::Eq for Tms320c64xOpMem {}
 
-impl<'a> From<&'a cs_tms320c64x_op> for Tms320c64xOperand {
+impl From<&cs_tms320c64x_op> for Tms320c64xOperand {
     fn from(insn: &cs_tms320c64x_op) -> Tms320c64xOperand {
         match insn.type_ {
             tms320c64x_op_type::TMS320C64X_OP_REG => {

--- a/capstone-rs/src/arch/x86.rs
+++ b/capstone-rs/src/arch/x86.rs
@@ -82,7 +82,7 @@ pub enum X86OperandType {
 #[derive(Debug, Copy, Clone)]
 pub struct X86OpMem(pub(crate) x86_op_mem);
 
-impl<'a> X86InsnDetail<'a> {
+impl X86InsnDetail<'_> {
     /// Instruction prefix, which can be up to 4 bytes.
     /// A prefix byte gets value 0 when irrelevant.
     /// See `X86Prefix` for details.
@@ -222,7 +222,7 @@ impl Default for X86Operand {
     }
 }
 
-impl<'a> From<&'a cs_x86_op> for X86Operand {
+impl From<&cs_x86_op> for X86Operand {
     fn from(op: &cs_x86_op) -> X86Operand {
         let op_type = X86OperandType::new(op.type_, op.__bindgen_anon_1);
         X86Operand {

--- a/capstone-rs/src/arch/xcore.rs
+++ b/capstone-rs/src/arch/xcore.rs
@@ -74,7 +74,7 @@ impl_PartialEq_repr_fields!(XcoreOpMem;
 
 impl cmp::Eq for XcoreOpMem {}
 
-impl<'a> From<&'a cs_xcore_op> for XcoreOperand {
+impl From<&cs_xcore_op> for XcoreOperand {
     fn from(insn: &cs_xcore_op) -> XcoreOperand {
         match insn.type_ {
             xcore_op_type::XCORE_OP_REG => {

--- a/capstone-rs/src/constants.rs
+++ b/capstone-rs/src/constants.rs
@@ -232,69 +232,69 @@ define_cs_enum_wrapper!(
         => Mode = cs_mode
     ]
     /// 32-bit ARM
-    => Arm = CS_MODE_ARM;
+    => Arm = { cs_mode::CS_MODE_ARM };
     /// 16-bit mode (X86)
-    => Mode16 = CS_MODE_16;
+    => Mode16 = { cs_mode::CS_MODE_16 };
     /// 32-bit mode (X86)
-    => Mode32 = CS_MODE_32;
+    => Mode32 = { cs_mode::CS_MODE_32 };
     /// 64-bit mode (X86, PPC)
-    => Mode64 = CS_MODE_64;
+    => Mode64 = { cs_mode::CS_MODE_64 };
     /// ARM's Thumb mode, including Thumb-2
-    => Thumb = CS_MODE_THUMB;
+    => Thumb = { cs_mode::CS_MODE_THUMB };
     /// Mips II ISA
-    => Mips2 = CS_MODE_MIPS2;
+    => Mips2 = { cs_mode::CS_MODE_MIPS2 };
     /// Mips III ISA
-    => Mips3 = CS_MODE_MIPS3;
+    => Mips3 = { cs_mode::CS_MODE_MIPS3 };
     /// Mips32r6 ISA
-    => Mips32R6 = CS_MODE_MIPS32R6;
+    => Mips32R6 = { cs_mode::CS_MODE_MIPS32R6 };
     /// Mips32 ISA (Mips)
-    => Mips32 = CS_MODE_MIPS32;
+    => Mips32 = { cs_mode::CS_MODE_MIPS32 };
     /// Mips64 ISA (Mips)
-    => Mips64 = CS_MODE_MIPS64;
+    => Mips64 = { cs_mode::CS_MODE_MIPS64 };
     /// SparcV9 mode (Sparc)
-    => V9 = CS_MODE_V9;
+    => V9 = { cs_mode::CS_MODE_V9 };
     /// Quad Processing eXtensions mode (PPC)
-    => Qpx = CS_MODE_QPX;
+    => Qpx = { cs_mode::CS_MODE_QPX };
     /// M68K 68000 mode
-    => M68k000 = CS_MODE_M68K_000;
+    => M68k000 = { cs_mode::CS_MODE_M68K_000 };
     /// M68K 68010 mode
-    => M68k010 = CS_MODE_M68K_010;
+    => M68k010 = { cs_mode::CS_MODE_M68K_010 };
     /// M68K 68020 mode
-    => M68k020 = CS_MODE_M68K_020;
+    => M68k020 = { cs_mode::CS_MODE_M68K_020 };
     /// M68K 68030 mode
-    => M68k030 = CS_MODE_M68K_030;
+    => M68k030 = { cs_mode::CS_MODE_M68K_030 };
     /// M68K 68040 mode
-    => M68k040 = CS_MODE_M68K_040;
+    => M68k040 = { cs_mode::CS_MODE_M68K_040 };
     /// M680X Hitachi 6301,6303 mode
-    => M680x6301 = CS_MODE_M680X_6301;
+    => M680x6301 = { cs_mode::CS_MODE_M680X_6301 };
     /// M680X Hitachi 6309 mode
-    => M680x6309 = CS_MODE_M680X_6309;
+    => M680x6309 = { cs_mode::CS_MODE_M680X_6309 };
     /// M680X Motorola 6800,6802 mode
-    => M680x6800 = CS_MODE_M680X_6800;
+    => M680x6800 = { cs_mode::CS_MODE_M680X_6800 };
     /// M680X Motorola 6801,6803 mode
-    => M680x6801 = CS_MODE_M680X_6801;
+    => M680x6801 = { cs_mode::CS_MODE_M680X_6801 };
     /// M680X Motorola/Freescale 6805 mode
-    => M680x6805 = CS_MODE_M680X_6805;
+    => M680x6805 = { cs_mode::CS_MODE_M680X_6805 };
     /// M680X Motorola/Freescale/NXP 68HC08 mode
-    => M680x6808 = CS_MODE_M680X_6808;
+    => M680x6808 = { cs_mode::CS_MODE_M680X_6808 };
     /// M680X Motorola 6809 mode
-    => M680x6809 = CS_MODE_M680X_6809;
+    => M680x6809 = { cs_mode::CS_MODE_M680X_6809 };
     /// M680X Motorola/Freescale/NXP 68HC11 mode
-    => M680x6811 = CS_MODE_M680X_6811;
+    => M680x6811 = { cs_mode::CS_MODE_M680X_6811 };
     /// M680X Motorola/Freescale/NXP CPU12
-    => M680xCpu12 = CS_MODE_M680X_CPU12;
+    => M680xCpu12 = { cs_mode::CS_MODE_M680X_CPU12 };
     /// M680X Freescale/NXP HCS08 mode
-    => M680xHcs08 = CS_MODE_M680X_HCS08;
+    => M680xHcs08 = { cs_mode::CS_MODE_M680X_HCS08 };
     /// RISC-V 32-bit mode
-    => RiscV32 = CS_MODE_RISCV32;
+    => RiscV32 = { cs_mode::CS_MODE_RISCV32 };
     /// RISC-V 64-bit mode
-    => RiscV64 = CS_MODE_RISCV64;
+    => RiscV64 = { cs_mode::CS_MODE_RISCV64 };
     /// Classic BPF mode
-    => Cbpf = CS_MODE_BPF_CLASSIC;
+    => Cbpf = { cs_mode::CS_MODE_BPF_CLASSIC };
     /// Extended BPF mode
-    => Ebpf = CS_MODE_BPF_EXTENDED;
+    => Ebpf = { cs_mode::CS_MODE_BPF_EXTENDED };
     /// Default mode for little-endian
-    => Default = CS_MODE_LITTLE_ENDIAN;
+    => Default = { cs_mode::CS_MODE_LITTLE_ENDIAN };
 );
 
 define_cs_enum_wrapper!(
@@ -303,13 +303,13 @@ define_cs_enum_wrapper!(
         => ExtraMode = cs_mode
     ]
     /// ARM's Cortex-M series. Works with `Arm` mode.
-    => MClass = CS_MODE_MCLASS;
+    => MClass = { cs_mode::CS_MODE_MCLASS };
     /// ARMv8 A32 encodings for ARM. Works with `Arm` and `Thumb` modes.
-    => V8 = CS_MODE_V8;
+    => V8 = { cs_mode::CS_MODE_V8 };
     /// MicroMips mode. Works in `MIPS` mode.
-    => Micro = CS_MODE_MICRO;
+    => Micro = { cs_mode::CS_MODE_MICRO };
     /// RISC-V compressed instruction mode
-    => RiscVC = CS_MODE_RISCVC;
+    => RiscVC = { cs_mode::CS_MODE_RISCVC };
 );
 
 define_cs_enum_wrapper!(
@@ -318,9 +318,9 @@ define_cs_enum_wrapper!(
         => Endian = cs_mode
     ]
     /// Little-endian mode
-    => Little = CS_MODE_LITTLE_ENDIAN;
+    => Little = { cs_mode::CS_MODE_LITTLE_ENDIAN };
     /// Big-endian mode
-    => Big = CS_MODE_BIG_ENDIAN;
+    => Big = { cs_mode::CS_MODE_BIG_ENDIAN };
 );
 
 define_cs_enum_wrapper!(

--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -143,7 +143,7 @@ impl<'a> AsRef<[Insn<'a>]> for Instructions<'a> {
     }
 }
 
-impl<'a> Drop for Instructions<'a> {
+impl Drop for Instructions<'_> {
     fn drop(&mut self) {
         if !self.is_empty() {
             unsafe {
@@ -199,7 +199,7 @@ pub struct Insn<'a> {
 pub struct InsnDetail<'a>(pub(crate) &'a cs_detail, pub(crate) Arch);
 
 #[allow(clippy::len_without_is_empty)]
-impl<'a> Insn<'a> {
+impl Insn<'_> {
     /// Create an `Insn` from a raw pointer to a [`capstone_sys::cs_insn`].
     ///
     /// This function serves to allow integration with libraries which generate `capstone_sys::cs_insn`'s internally.
@@ -280,7 +280,7 @@ impl<'a> Insn<'a> {
     }
 }
 
-impl<'a> From<&Insn<'_>> for OwnedInsn<'a> {
+impl From<&Insn<'_>> for OwnedInsn<'_> {
     // SAFETY: assumes that `cs_detail` struct transitively only contains owned
     // types and no pointers, including the union over the architecture-specific
     // types.
@@ -324,7 +324,7 @@ pub struct OwnedInsn<'a> {
     pub(crate) _marker: PhantomData<&'a InsnDetail<'a>>,
 }
 
-impl<'a> Debug for Insn<'a> {
+impl Debug for Insn<'_> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         fmt.debug_struct("Insn")
             .field("address", &self.address())
@@ -336,7 +336,7 @@ impl<'a> Debug for Insn<'a> {
     }
 }
 
-impl<'a> Display for Insn<'a> {
+impl Display for Insn<'_> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         write!(fmt, "{:#x}: ", self.address())?;
         if let Some(mnemonic) = self.mnemonic() {
@@ -349,7 +349,7 @@ impl<'a> Display for Insn<'a> {
     }
 }
 
-impl<'a> Drop for OwnedInsn<'a> {
+impl Drop for OwnedInsn<'_> {
     fn drop(&mut self) {
         if let Some(ptr) = core::ptr::NonNull::new(self.insn.detail) {
             unsafe { drop(Box::from_raw(ptr.as_ptr())) }
@@ -357,19 +357,19 @@ impl<'a> Drop for OwnedInsn<'a> {
     }
 }
 
-impl<'a> Debug for OwnedInsn<'a> {
+impl Debug for OwnedInsn<'_> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         Debug::fmt(&self.deref(), fmt)
     }
 }
 
-impl<'a> Display for OwnedInsn<'a> {
+impl Display for OwnedInsn<'_> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         Display::fmt(&self.deref(), fmt)
     }
 }
 
-impl<'a> InsnDetail<'a> {
+impl InsnDetail<'_> {
     #[cfg(feature = "full")]
     /// Returns the implicit read registers
     pub fn regs_read(&self) -> &[RegId] {
@@ -436,7 +436,7 @@ impl<'a> InsnDetail<'a> {
 }
 
 #[cfg(feature = "full")]
-impl<'a> Debug for InsnDetail<'a> {
+impl Debug for InsnDetail<'_> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         fmt.debug_struct("Detail")
             .field("regs_read", &self.regs_read())
@@ -453,7 +453,7 @@ impl<'a> Debug for InsnDetail<'a> {
     }
 }
 
-impl<'a> Display for Instructions<'a> {
+impl Display for Instructions<'_> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         for instruction in self.iter() {
             write!(fmt, "{:x}:\t", instruction.address())?;

--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -100,13 +100,13 @@ impl TryFrom<cs_ac_type> for RegAccessType {
 
     fn try_from(access: cs_ac_type) -> Result<Self, Self::Error> {
         // Check for flags other than CS_AC_READ or CS_AC_WRITE.
-        let unknown_flag_mask = !(CS_AC_READ | CS_AC_WRITE).0;
+        let unknown_flag_mask = !(cs_ac_type::CS_AC_READ | cs_ac_type::CS_AC_WRITE).0;
         if (access.0 & unknown_flag_mask) != 0 {
             return Err(());
         }
 
-        let is_readable = (access & CS_AC_READ).0 != 0;
-        let is_writable = (access & CS_AC_WRITE).0 != 0;
+        let is_readable = (access & cs_ac_type::CS_AC_READ).0 != 0;
+        let is_writable = (access & cs_ac_type::CS_AC_WRITE).0 != 0;
         match (is_readable, is_writable) {
             (true, false) => Ok(RegAccessType::ReadOnly),
             (false, true) => Ok(RegAccessType::WriteOnly),

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -120,12 +120,12 @@ fn test_x86_names() {
             assert_eq!(cs.group_name(InsnGroupId(1)), Some(String::from("jump")));
 
             let reg_id = RegId(250);
-            if let Some(_) = cs.reg_name(reg_id) {
+            if cs.reg_name(reg_id).is_some() {
                 panic!("invalid register worked")
             }
 
             let insn_id = InsnId(6000);
-            if let Some(_) = cs.insn_name(insn_id) {
+            if cs.insn_name(insn_id).is_some() {
                 panic!("invalid instruction worked")
             }
 

--- a/capstone-sys/build.rs
+++ b/capstone-sys/build.rs
@@ -243,7 +243,7 @@ fn write_bindgen_bindings(
 ) {
     #[allow(deprecated)]
     let mut builder = bindgen::Builder::default()
-        .rust_target(bindgen::RustTarget::Stable_1_19)
+        .rust_target(bindgen::RustTarget::Stable_1_28)
         .size_t_is_usize(true)
         .use_core()
         .ctypes_prefix("libc")

--- a/capstone-sys/common.rs
+++ b/capstone-sys/common.rs
@@ -12,7 +12,7 @@ pub struct CapstoneArchInfo<'a> {
     cs_name: &'a str,
 }
 
-impl<'a> CapstoneArchInfo<'a> {
+impl CapstoneArchInfo<'_> {
     /// Get the name of the C header
     pub fn header_name(&self) -> &str {
         self.header_name

--- a/capstone-sys/pre_generated/capstone.rs
+++ b/capstone-sys/pre_generated/capstone.rs
@@ -41,99 +41,193 @@ pub enum cs_arch {
     CS_ARCH_MAX = 16,
     CS_ARCH_ALL = 65535,
 }
-#[doc = "< little-endian mode (default mode)"]
-pub const CS_MODE_LITTLE_ENDIAN: cs_mode = cs_mode(0);
-#[doc = "< 32-bit ARM"]
-pub const CS_MODE_ARM: cs_mode = cs_mode(0);
-#[doc = "< 16-bit mode (X86)"]
-pub const CS_MODE_16: cs_mode = cs_mode(2);
-#[doc = "< 32-bit mode (X86)"]
-pub const CS_MODE_32: cs_mode = cs_mode(4);
-#[doc = "< 64-bit mode (X86, PPC)"]
-pub const CS_MODE_64: cs_mode = cs_mode(8);
-#[doc = "< ARM's Thumb mode, including Thumb-2"]
-pub const CS_MODE_THUMB: cs_mode = cs_mode(16);
-#[doc = "< ARM's Cortex-M series"]
-pub const CS_MODE_MCLASS: cs_mode = cs_mode(32);
-#[doc = "< ARMv8 A32 encodings for ARM"]
-pub const CS_MODE_V8: cs_mode = cs_mode(64);
-#[doc = "< MicroMips mode (MIPS)"]
-pub const CS_MODE_MICRO: cs_mode = cs_mode(16);
-#[doc = "< Mips III ISA"]
-pub const CS_MODE_MIPS3: cs_mode = cs_mode(32);
-#[doc = "< Mips32r6 ISA"]
-pub const CS_MODE_MIPS32R6: cs_mode = cs_mode(64);
-#[doc = "< Mips II ISA"]
-pub const CS_MODE_MIPS2: cs_mode = cs_mode(128);
-#[doc = "< SparcV9 mode (Sparc)"]
-pub const CS_MODE_V9: cs_mode = cs_mode(16);
-#[doc = "< Quad Processing eXtensions mode (PPC)"]
-pub const CS_MODE_QPX: cs_mode = cs_mode(16);
-#[doc = "< Signal Processing Engine mode (PPC)"]
-pub const CS_MODE_SPE: cs_mode = cs_mode(32);
-#[doc = "< Book-E mode (PPC)"]
-pub const CS_MODE_BOOKE: cs_mode = cs_mode(64);
-#[doc = "< M68K 68000 mode"]
-pub const CS_MODE_M68K_000: cs_mode = cs_mode(2);
-#[doc = "< M68K 68010 mode"]
-pub const CS_MODE_M68K_010: cs_mode = cs_mode(4);
-#[doc = "< M68K 68020 mode"]
-pub const CS_MODE_M68K_020: cs_mode = cs_mode(8);
-#[doc = "< M68K 68030 mode"]
-pub const CS_MODE_M68K_030: cs_mode = cs_mode(16);
-#[doc = "< M68K 68040 mode"]
-pub const CS_MODE_M68K_040: cs_mode = cs_mode(32);
-#[doc = "< M68K 68060 mode"]
-pub const CS_MODE_M68K_060: cs_mode = cs_mode(64);
-#[doc = "< big-endian mode"]
-pub const CS_MODE_BIG_ENDIAN: cs_mode = cs_mode(2147483648);
-#[doc = "< Mips32 ISA (Mips)"]
-pub const CS_MODE_MIPS32: cs_mode = cs_mode(4);
-#[doc = "< Mips64 ISA (Mips)"]
-pub const CS_MODE_MIPS64: cs_mode = cs_mode(8);
-#[doc = "< M680X Hitachi 6301,6303 mode"]
-pub const CS_MODE_M680X_6301: cs_mode = cs_mode(2);
-#[doc = "< M680X Hitachi 6309 mode"]
-pub const CS_MODE_M680X_6309: cs_mode = cs_mode(4);
-#[doc = "< M680X Motorola 6800,6802 mode"]
-pub const CS_MODE_M680X_6800: cs_mode = cs_mode(8);
-#[doc = "< M680X Motorola 6801,6803 mode"]
-pub const CS_MODE_M680X_6801: cs_mode = cs_mode(16);
-#[doc = "< M680X Motorola/Freescale 6805 mode"]
-pub const CS_MODE_M680X_6805: cs_mode = cs_mode(32);
-#[doc = "< M680X Motorola/Freescale/NXP 68HC08 mode"]
-pub const CS_MODE_M680X_6808: cs_mode = cs_mode(64);
-#[doc = "< M680X Motorola 6809 mode"]
-pub const CS_MODE_M680X_6809: cs_mode = cs_mode(128);
-#[doc = "< M680X Motorola/Freescale/NXP 68HC11 mode"]
-pub const CS_MODE_M680X_6811: cs_mode = cs_mode(256);
-#[doc = "< M680X Motorola/Freescale/NXP CPU12\n< used on M68HC12/HCS12"]
-pub const CS_MODE_M680X_CPU12: cs_mode = cs_mode(512);
-#[doc = "< M680X Freescale/NXP HCS08 mode"]
-pub const CS_MODE_M680X_HCS08: cs_mode = cs_mode(1024);
-#[doc = "< Classic BPF mode (default)"]
-pub const CS_MODE_BPF_CLASSIC: cs_mode = cs_mode(0);
-#[doc = "< Extended BPF mode"]
-pub const CS_MODE_BPF_EXTENDED: cs_mode = cs_mode(1);
-#[doc = "< RISCV RV32G"]
-pub const CS_MODE_RISCV32: cs_mode = cs_mode(1);
-#[doc = "< RISCV RV64G"]
-pub const CS_MODE_RISCV64: cs_mode = cs_mode(2);
-#[doc = "< RISCV compressed instructure mode"]
-pub const CS_MODE_RISCVC: cs_mode = cs_mode(4);
-#[doc = "< MOS65XXX MOS 6502"]
-pub const CS_MODE_MOS65XX_6502: cs_mode = cs_mode(2);
-#[doc = "< MOS65XXX WDC 65c02"]
-pub const CS_MODE_MOS65XX_65C02: cs_mode = cs_mode(4);
-#[doc = "< MOS65XXX WDC W65c02"]
-pub const CS_MODE_MOS65XX_W65C02: cs_mode = cs_mode(8);
-#[doc = "< MOS65XXX WDC 65816, 8-bit m/x"]
-pub const CS_MODE_MOS65XX_65816: cs_mode = cs_mode(16);
-#[doc = "< MOS65XXX WDC 65816, 16-bit m, 8-bit x"]
-pub const CS_MODE_MOS65XX_65816_LONG_M: cs_mode = cs_mode(32);
-#[doc = "< MOS65XXX WDC 65816, 8-bit m, 16-bit x"]
-pub const CS_MODE_MOS65XX_65816_LONG_X: cs_mode = cs_mode(64);
-pub const CS_MODE_MOS65XX_65816_LONG_MX: cs_mode = cs_mode(96);
+impl cs_mode {
+    #[doc = "< little-endian mode (default mode)"]
+    pub const CS_MODE_LITTLE_ENDIAN: cs_mode = cs_mode(0);
+}
+impl cs_mode {
+    #[doc = "< 32-bit ARM"]
+    pub const CS_MODE_ARM: cs_mode = cs_mode(0);
+}
+impl cs_mode {
+    #[doc = "< 16-bit mode (X86)"]
+    pub const CS_MODE_16: cs_mode = cs_mode(2);
+}
+impl cs_mode {
+    #[doc = "< 32-bit mode (X86)"]
+    pub const CS_MODE_32: cs_mode = cs_mode(4);
+}
+impl cs_mode {
+    #[doc = "< 64-bit mode (X86, PPC)"]
+    pub const CS_MODE_64: cs_mode = cs_mode(8);
+}
+impl cs_mode {
+    #[doc = "< ARM's Thumb mode, including Thumb-2"]
+    pub const CS_MODE_THUMB: cs_mode = cs_mode(16);
+}
+impl cs_mode {
+    #[doc = "< ARM's Cortex-M series"]
+    pub const CS_MODE_MCLASS: cs_mode = cs_mode(32);
+}
+impl cs_mode {
+    #[doc = "< ARMv8 A32 encodings for ARM"]
+    pub const CS_MODE_V8: cs_mode = cs_mode(64);
+}
+impl cs_mode {
+    #[doc = "< MicroMips mode (MIPS)"]
+    pub const CS_MODE_MICRO: cs_mode = cs_mode(16);
+}
+impl cs_mode {
+    #[doc = "< Mips III ISA"]
+    pub const CS_MODE_MIPS3: cs_mode = cs_mode(32);
+}
+impl cs_mode {
+    #[doc = "< Mips32r6 ISA"]
+    pub const CS_MODE_MIPS32R6: cs_mode = cs_mode(64);
+}
+impl cs_mode {
+    #[doc = "< Mips II ISA"]
+    pub const CS_MODE_MIPS2: cs_mode = cs_mode(128);
+}
+impl cs_mode {
+    #[doc = "< SparcV9 mode (Sparc)"]
+    pub const CS_MODE_V9: cs_mode = cs_mode(16);
+}
+impl cs_mode {
+    #[doc = "< Quad Processing eXtensions mode (PPC)"]
+    pub const CS_MODE_QPX: cs_mode = cs_mode(16);
+}
+impl cs_mode {
+    #[doc = "< Signal Processing Engine mode (PPC)"]
+    pub const CS_MODE_SPE: cs_mode = cs_mode(32);
+}
+impl cs_mode {
+    #[doc = "< Book-E mode (PPC)"]
+    pub const CS_MODE_BOOKE: cs_mode = cs_mode(64);
+}
+impl cs_mode {
+    #[doc = "< M68K 68000 mode"]
+    pub const CS_MODE_M68K_000: cs_mode = cs_mode(2);
+}
+impl cs_mode {
+    #[doc = "< M68K 68010 mode"]
+    pub const CS_MODE_M68K_010: cs_mode = cs_mode(4);
+}
+impl cs_mode {
+    #[doc = "< M68K 68020 mode"]
+    pub const CS_MODE_M68K_020: cs_mode = cs_mode(8);
+}
+impl cs_mode {
+    #[doc = "< M68K 68030 mode"]
+    pub const CS_MODE_M68K_030: cs_mode = cs_mode(16);
+}
+impl cs_mode {
+    #[doc = "< M68K 68040 mode"]
+    pub const CS_MODE_M68K_040: cs_mode = cs_mode(32);
+}
+impl cs_mode {
+    #[doc = "< M68K 68060 mode"]
+    pub const CS_MODE_M68K_060: cs_mode = cs_mode(64);
+}
+impl cs_mode {
+    #[doc = "< big-endian mode"]
+    pub const CS_MODE_BIG_ENDIAN: cs_mode = cs_mode(2147483648);
+}
+impl cs_mode {
+    #[doc = "< Mips32 ISA (Mips)"]
+    pub const CS_MODE_MIPS32: cs_mode = cs_mode(4);
+}
+impl cs_mode {
+    #[doc = "< Mips64 ISA (Mips)"]
+    pub const CS_MODE_MIPS64: cs_mode = cs_mode(8);
+}
+impl cs_mode {
+    #[doc = "< M680X Hitachi 6301,6303 mode"]
+    pub const CS_MODE_M680X_6301: cs_mode = cs_mode(2);
+}
+impl cs_mode {
+    #[doc = "< M680X Hitachi 6309 mode"]
+    pub const CS_MODE_M680X_6309: cs_mode = cs_mode(4);
+}
+impl cs_mode {
+    #[doc = "< M680X Motorola 6800,6802 mode"]
+    pub const CS_MODE_M680X_6800: cs_mode = cs_mode(8);
+}
+impl cs_mode {
+    #[doc = "< M680X Motorola 6801,6803 mode"]
+    pub const CS_MODE_M680X_6801: cs_mode = cs_mode(16);
+}
+impl cs_mode {
+    #[doc = "< M680X Motorola/Freescale 6805 mode"]
+    pub const CS_MODE_M680X_6805: cs_mode = cs_mode(32);
+}
+impl cs_mode {
+    #[doc = "< M680X Motorola/Freescale/NXP 68HC08 mode"]
+    pub const CS_MODE_M680X_6808: cs_mode = cs_mode(64);
+}
+impl cs_mode {
+    #[doc = "< M680X Motorola 6809 mode"]
+    pub const CS_MODE_M680X_6809: cs_mode = cs_mode(128);
+}
+impl cs_mode {
+    #[doc = "< M680X Motorola/Freescale/NXP 68HC11 mode"]
+    pub const CS_MODE_M680X_6811: cs_mode = cs_mode(256);
+}
+impl cs_mode {
+    #[doc = "< M680X Motorola/Freescale/NXP CPU12\n< used on M68HC12/HCS12"]
+    pub const CS_MODE_M680X_CPU12: cs_mode = cs_mode(512);
+}
+impl cs_mode {
+    #[doc = "< M680X Freescale/NXP HCS08 mode"]
+    pub const CS_MODE_M680X_HCS08: cs_mode = cs_mode(1024);
+}
+impl cs_mode {
+    #[doc = "< Classic BPF mode (default)"]
+    pub const CS_MODE_BPF_CLASSIC: cs_mode = cs_mode(0);
+}
+impl cs_mode {
+    #[doc = "< Extended BPF mode"]
+    pub const CS_MODE_BPF_EXTENDED: cs_mode = cs_mode(1);
+}
+impl cs_mode {
+    #[doc = "< RISCV RV32G"]
+    pub const CS_MODE_RISCV32: cs_mode = cs_mode(1);
+}
+impl cs_mode {
+    #[doc = "< RISCV RV64G"]
+    pub const CS_MODE_RISCV64: cs_mode = cs_mode(2);
+}
+impl cs_mode {
+    #[doc = "< RISCV compressed instructure mode"]
+    pub const CS_MODE_RISCVC: cs_mode = cs_mode(4);
+}
+impl cs_mode {
+    #[doc = "< MOS65XXX MOS 6502"]
+    pub const CS_MODE_MOS65XX_6502: cs_mode = cs_mode(2);
+}
+impl cs_mode {
+    #[doc = "< MOS65XXX WDC 65c02"]
+    pub const CS_MODE_MOS65XX_65C02: cs_mode = cs_mode(4);
+}
+impl cs_mode {
+    #[doc = "< MOS65XXX WDC W65c02"]
+    pub const CS_MODE_MOS65XX_W65C02: cs_mode = cs_mode(8);
+}
+impl cs_mode {
+    #[doc = "< MOS65XXX WDC 65816, 8-bit m/x"]
+    pub const CS_MODE_MOS65XX_65816: cs_mode = cs_mode(16);
+}
+impl cs_mode {
+    #[doc = "< MOS65XXX WDC 65816, 16-bit m, 8-bit x"]
+    pub const CS_MODE_MOS65XX_65816_LONG_M: cs_mode = cs_mode(32);
+}
+impl cs_mode {
+    #[doc = "< MOS65XXX WDC 65816, 8-bit m, 16-bit x"]
+    pub const CS_MODE_MOS65XX_65816_LONG_X: cs_mode = cs_mode(64);
+}
+impl cs_mode {
+    pub const CS_MODE_MOS65XX_65816_LONG_MX: cs_mode = cs_mode(96);
+}
 impl ::core::ops::BitOr<cs_mode> for cs_mode {
     type Output = Self;
     #[inline]
@@ -160,7 +254,7 @@ impl ::core::ops::BitAndAssign for cs_mode {
         self.0 &= rhs.0;
     }
 }
-#[repr(C)]
+#[repr(transparent)]
 #[doc = " Mode type"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct cs_mode(pub libc::c_uint);
@@ -182,7 +276,7 @@ pub type cs_vsnprintf_t = ::core::option::Option<
 >;
 #[doc = " User-defined dynamic memory related functions: malloc/calloc/realloc/free/vsnprintf()\n By default, Capstone uses system's malloc(), calloc(), realloc(), free() & vsnprintf()."]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct cs_opt_mem {
     pub malloc: cs_malloc_t,
     pub calloc: cs_calloc_t,
@@ -190,24 +284,14 @@ pub struct cs_opt_mem {
     pub free: cs_free_t,
     pub vsnprintf: cs_vsnprintf_t,
 }
-impl Clone for cs_opt_mem {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[doc = " Customize mnemonic for instructions with alternative name.\n To reset existing customized instruction to its default mnemonic,\n call cs_option(CS_OPT_MNEMONIC) again with the same @id and NULL value\n for @mnemonic."]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct cs_opt_mnem {
     #[doc = " ID of instruction to be customized."]
     pub id: libc::c_uint,
     #[doc = " Customized instruction mnemonic."]
     pub mnemonic: *const libc::c_char,
-}
-impl Clone for cs_opt_mnem {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 #[repr(u32)]
 #[doc = " Runtime option for the disassembled engine"]
@@ -267,12 +351,18 @@ pub enum cs_op_type {
     #[doc = "< Floating-Point operand."]
     CS_OP_FP = 4,
 }
-#[doc = "< Uninitialized/invalid access type."]
-pub const CS_AC_INVALID: cs_ac_type = cs_ac_type(0);
-#[doc = "< Operand read from memory or register."]
-pub const CS_AC_READ: cs_ac_type = cs_ac_type(1);
-#[doc = "< Operand write to memory or register."]
-pub const CS_AC_WRITE: cs_ac_type = cs_ac_type(2);
+impl cs_ac_type {
+    #[doc = "< Uninitialized/invalid access type."]
+    pub const CS_AC_INVALID: cs_ac_type = cs_ac_type(0);
+}
+impl cs_ac_type {
+    #[doc = "< Operand read from memory or register."]
+    pub const CS_AC_READ: cs_ac_type = cs_ac_type(1);
+}
+impl cs_ac_type {
+    #[doc = "< Operand write to memory or register."]
+    pub const CS_AC_WRITE: cs_ac_type = cs_ac_type(2);
+}
 impl ::core::ops::BitOr<cs_ac_type> for cs_ac_type {
     type Output = Self;
     #[inline]
@@ -299,7 +389,7 @@ impl ::core::ops::BitAndAssign for cs_ac_type {
         self.0 &= rhs.0;
     }
 }
-#[repr(C)]
+#[repr(transparent)]
 #[doc = " Common instruction operand access types - to be consistent across all architectures.\n It is possible to combine access types, for example: CS_AC_READ | CS_AC_WRITE"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct cs_ac_type(pub libc::c_uint);
@@ -334,7 +424,7 @@ pub type cs_skipdata_cb_t = ::core::option::Option<
 >;
 #[doc = " User-customized setup for SKIPDATA option"]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct cs_opt_skipdata {
     #[doc = " Capstone considers data to skip as special \"instructions\".\n User can specify the string for this instruction's \"mnemonic\" here.\n By default (if @mnemonic is NULL), Capstone use \".byte\"."]
     pub mnemonic: *const libc::c_char,
@@ -342,11 +432,6 @@ pub struct cs_opt_skipdata {
     pub callback: cs_skipdata_cb_t,
     #[doc = " User-defined data to be passed to @callback function pointer."]
     pub user_data: *mut libc::c_void,
-}
-impl Clone for cs_opt_skipdata {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 #[repr(u32)]
 #[doc = " ARM shift type"]
@@ -819,7 +904,7 @@ pub mod arm_reg {
 }
 #[doc = " Instruction's operand referring to memory\n This is associated with ARM_OP_MEM operand type above"]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct arm_op_mem {
     #[doc = "< base register"]
     pub base: arm_reg::Type,
@@ -832,14 +917,9 @@ pub struct arm_op_mem {
     #[doc = " left-shift on index register, or 0 if irrelevant\n NOTE: this value can also be fetched via operand.shift.value"]
     pub lshift: libc::c_int,
 }
-impl Clone for arm_op_mem {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[doc = " Instruction operand"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_arm_op {
     #[doc = "< Vector Index for some vector operands (or -1 if irrelevant)"]
     pub vector_index: libc::c_int,
@@ -855,18 +935,13 @@ pub struct cs_arm_op {
     pub neon_lane: i8,
 }
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct cs_arm_op__bindgen_ty_1 {
     pub type_: arm_shifter,
     pub value: libc::c_uint,
 }
-impl Clone for cs_arm_op__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_arm_op__bindgen_ty_2 {
     #[doc = "< register value for REG/SYSREG operand"]
     pub reg: libc::c_int,
@@ -879,19 +954,9 @@ pub union cs_arm_op__bindgen_ty_2 {
     #[doc = "< SETEND instruction's operand type"]
     pub setend: arm_setend_type,
 }
-impl Clone for cs_arm_op__bindgen_ty_2 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_arm_op__bindgen_ty_2 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_arm_op__bindgen_ty_2 {{ union }}")
-    }
-}
-impl Clone for cs_arm_op {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_arm_op {
@@ -901,7 +966,7 @@ impl ::core::fmt::Debug for cs_arm_op {
 }
 #[doc = " Instruction structure"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_arm {
     #[doc = "< User-mode registers to be loaded (for LDM/STM instructions)"]
     pub usermode: bool,
@@ -925,11 +990,6 @@ pub struct cs_arm {
     pub op_count: u8,
     #[doc = "< operands for this instruction."]
     pub operands: [cs_arm_op; 36usize],
-}
-impl Clone for cs_arm {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl ::core::fmt::Debug for cs_arm {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1526,7 +1586,9 @@ pub enum arm64_cc {
     #[doc = "< Always (unconditional):   Always (unconditional)"]
     ARM64_CC_NV = 16,
 }
-pub const ARM64_SYSREG_DBGDTRTX_EL0: arm64_sysreg = arm64_sysreg::ARM64_SYSREG_DBGDTRRX_EL0;
+impl arm64_sysreg {
+    pub const ARM64_SYSREG_DBGDTRTX_EL0: arm64_sysreg = arm64_sysreg::ARM64_SYSREG_DBGDTRRX_EL0;
+}
 #[repr(u32)]
 #[doc = " System registers"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2906,7 +2968,7 @@ pub mod arm64_reg {
 }
 #[doc = " Instruction's operand referring to memory\n This is associated with ARM64_OP_MEM operand type above"]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct arm64_op_mem {
     #[doc = "< base register"]
     pub base: arm64_reg::Type,
@@ -2915,14 +2977,9 @@ pub struct arm64_op_mem {
     #[doc = "< displacement/offset value"]
     pub disp: i32,
 }
-impl Clone for arm64_op_mem {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[doc = " Instruction operand"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_arm64_op {
     #[doc = "< Vector Index for some vector operands (or -1 if irrelevant)"]
     pub vector_index: libc::c_int,
@@ -2938,20 +2995,15 @@ pub struct cs_arm64_op {
     pub access: u8,
 }
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct cs_arm64_op__bindgen_ty_1 {
     #[doc = "< shifter type of this operand"]
     pub type_: arm64_shifter,
     #[doc = "< shifter value of this operand"]
     pub value: libc::c_uint,
 }
-impl Clone for cs_arm64_op__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_arm64_op__bindgen_ty_2 {
     #[doc = "< register value for REG operand"]
     pub reg: arm64_reg::Type,
@@ -2970,19 +3022,9 @@ pub union cs_arm64_op__bindgen_ty_2 {
     #[doc = "< Memory barrier operation (ISB/DMB/DSB instructions)."]
     pub barrier: arm64_barrier_op,
 }
-impl Clone for cs_arm64_op__bindgen_ty_2 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_arm64_op__bindgen_ty_2 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_arm64_op__bindgen_ty_2 {{ union }}")
-    }
-}
-impl Clone for cs_arm64_op {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_arm64_op {
@@ -2992,7 +3034,7 @@ impl ::core::fmt::Debug for cs_arm64_op {
 }
 #[doc = " Instruction structure"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_arm64 {
     #[doc = "< conditional code for this insn"]
     pub cc: arm64_cc,
@@ -3004,11 +3046,6 @@ pub struct cs_arm64 {
     pub op_count: u8,
     #[doc = "< operands for this instruction."]
     pub operands: [cs_arm64_op; 8usize],
-}
-impl Clone for cs_arm64 {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl ::core::fmt::Debug for cs_arm64 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -4131,7 +4168,7 @@ pub enum m68k_op_type {
 }
 #[doc = " Instruction's operand referring to memory\n This is associated with M68K_OP_MEM operand type above"]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct m68k_op_mem {
     #[doc = "< base register (or M68K_REG_INVALID if irrelevant)"]
     pub base_reg: m68k_reg::Type,
@@ -4156,11 +4193,6 @@ pub struct m68k_op_mem {
     #[doc = "< 0 = w, 1 = l"]
     pub index_size: u8,
 }
-impl Clone for m68k_op_mem {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[repr(u32)]
 #[doc = " Operand type for instruction's operands"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -4175,33 +4207,23 @@ pub enum m68k_op_br_disp_size {
     M68K_OP_BR_DISP_SIZE_LONG = 4,
 }
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct m68k_op_br_disp {
     #[doc = "< displacement value"]
     pub disp: i32,
     #[doc = "< Size from m68k_op_br_disp_size type above"]
     pub disp_size: u8,
 }
-impl Clone for m68k_op_br_disp {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[doc = " Register pair in one operand."]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct cs_m68k_op_reg_pair {
     pub reg_0: m68k_reg::Type,
     pub reg_1: m68k_reg::Type,
 }
-impl Clone for cs_m68k_op_reg_pair {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[doc = " Instruction operand"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_m68k_op {
     pub __bindgen_anon_1: cs_m68k_op__bindgen_ty_1,
     #[doc = "< data when operand is targeting memory"]
@@ -4215,7 +4237,7 @@ pub struct cs_m68k_op {
     pub address_mode: m68k_address_mode,
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_m68k_op__bindgen_ty_1 {
     #[doc = "< immediate value for IMM operand"]
     pub imm: u64,
@@ -4228,19 +4250,9 @@ pub union cs_m68k_op__bindgen_ty_1 {
     #[doc = "< register pair in one operand"]
     pub reg_pair: cs_m68k_op_reg_pair,
 }
-impl Clone for cs_m68k_op__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_m68k_op__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_m68k_op__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for cs_m68k_op {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_m68k_op {
@@ -4284,30 +4296,20 @@ pub enum m68k_size_type {
 }
 #[doc = " Operation size of the current instruction (NOT the actually size of instruction)"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct m68k_op_size {
     pub type_: m68k_size_type,
     pub __bindgen_anon_1: m68k_op_size__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union m68k_op_size__bindgen_ty_1 {
     pub cpu_size: m68k_cpu_size,
     pub fpu_size: m68k_fpu_size,
 }
-impl Clone for m68k_op_size__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for m68k_op_size__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "m68k_op_size__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for m68k_op_size {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for m68k_op_size {
@@ -4321,7 +4323,7 @@ impl ::core::fmt::Debug for m68k_op_size {
 }
 #[doc = " The M68K instruction and it's operands"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_m68k {
     #[doc = "< operands for this instruction."]
     pub operands: [cs_m68k_op; 4usize],
@@ -4329,11 +4331,6 @@ pub struct cs_m68k {
     pub op_size: m68k_op_size,
     #[doc = "< number of operands for the instruction"]
     pub op_count: u8,
-}
-impl Clone for cs_m68k {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl ::core::fmt::Debug for cs_m68k {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -4939,28 +4936,23 @@ pub mod mips_reg {
 }
 #[doc = " Instruction's operand referring to memory\n This is associated with MIPS_OP_MEM operand type above"]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct mips_op_mem {
     #[doc = "< base register"]
     pub base: mips_reg::Type,
     #[doc = "< displacement/offset value"]
     pub disp: i64,
 }
-impl Clone for mips_op_mem {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[doc = " Instruction operand"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_mips_op {
     #[doc = "< operand type"]
     pub type_: mips_op_type,
     pub __bindgen_anon_1: cs_mips_op__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_mips_op__bindgen_ty_1 {
     #[doc = "< register id for REG operand"]
     pub reg: mips_reg::Type,
@@ -4969,19 +4961,9 @@ pub union cs_mips_op__bindgen_ty_1 {
     #[doc = "< base/index/scale/disp value for MEM operand"]
     pub mem: mips_op_mem,
 }
-impl Clone for cs_mips_op__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_mips_op__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_mips_op__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for cs_mips_op {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_mips_op {
@@ -4995,17 +4977,12 @@ impl ::core::fmt::Debug for cs_mips_op {
 }
 #[doc = " Instruction structure"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_mips {
     #[doc = " Number of operands of this instruction,\n or 0 when instruction has no operand."]
     pub op_count: u8,
     #[doc = "< operands for this instruction."]
     pub operands: [cs_mips_op; 10usize],
-}
-impl Clone for cs_mips {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl ::core::fmt::Debug for cs_mips {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -5991,40 +5968,30 @@ pub mod ppc_reg {
 }
 #[doc = " Instruction's operand referring to memory\n This is associated with PPC_OP_MEM operand type above"]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct ppc_op_mem {
     #[doc = "< base register"]
     pub base: ppc_reg::Type,
     #[doc = "< displacement/offset value"]
     pub disp: i32,
 }
-impl Clone for ppc_op_mem {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct ppc_op_crx {
     pub scale: libc::c_uint,
     pub reg: ppc_reg::Type,
     pub cond: ppc_bc,
 }
-impl Clone for ppc_op_crx {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[doc = " Instruction operand"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_ppc_op {
     #[doc = "< operand type"]
     pub type_: ppc_op_type,
     pub __bindgen_anon_1: cs_ppc_op__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_ppc_op__bindgen_ty_1 {
     #[doc = "< register value for REG operand"]
     pub reg: ppc_reg::Type,
@@ -6035,19 +6002,9 @@ pub union cs_ppc_op__bindgen_ty_1 {
     #[doc = "< operand with condition register"]
     pub crx: ppc_op_crx,
 }
-impl Clone for cs_ppc_op__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_ppc_op__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_ppc_op__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for cs_ppc_op {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_ppc_op {
@@ -6061,7 +6018,7 @@ impl ::core::fmt::Debug for cs_ppc_op {
 }
 #[doc = " Instruction structure"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_ppc {
     #[doc = " branch code for branch instructions"]
     pub bc: ppc_bc,
@@ -6073,11 +6030,6 @@ pub struct cs_ppc {
     pub op_count: u8,
     #[doc = "< operands for this instruction."]
     pub operands: [cs_ppc_op; 8usize],
-}
-impl Clone for cs_ppc {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl ::core::fmt::Debug for cs_ppc {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -8000,7 +7952,7 @@ pub mod sparc_reg {
 }
 #[doc = " Instruction's operand referring to memory\n This is associated with SPARC_OP_MEM operand type above"]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct sparc_op_mem {
     #[doc = "< base register, can be safely interpreted as\n< a value of type `sparc_reg`, but it is only\n< one byte wide"]
     pub base: u8,
@@ -8009,21 +7961,16 @@ pub struct sparc_op_mem {
     #[doc = "< displacement/offset value"]
     pub disp: i32,
 }
-impl Clone for sparc_op_mem {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[doc = " Instruction operand"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_sparc_op {
     #[doc = "< operand type"]
     pub type_: sparc_op_type,
     pub __bindgen_anon_1: cs_sparc_op__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_sparc_op__bindgen_ty_1 {
     #[doc = "< register value for REG operand"]
     pub reg: sparc_reg::Type,
@@ -8032,19 +7979,9 @@ pub union cs_sparc_op__bindgen_ty_1 {
     #[doc = "< base/disp value for MEM operand"]
     pub mem: sparc_op_mem,
 }
-impl Clone for cs_sparc_op__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_sparc_op__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_sparc_op__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for cs_sparc_op {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_sparc_op {
@@ -8058,7 +7995,7 @@ impl ::core::fmt::Debug for cs_sparc_op {
 }
 #[doc = " Instruction structure"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_sparc {
     #[doc = "< code condition for this insn"]
     pub cc: sparc_cc,
@@ -8068,11 +8005,6 @@ pub struct cs_sparc {
     pub op_count: u8,
     #[doc = "< operands for this instruction."]
     pub operands: [cs_sparc_op; 4usize],
-}
-impl Clone for cs_sparc {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl ::core::fmt::Debug for cs_sparc {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -8544,7 +8476,7 @@ pub mod sysz_reg {
 }
 #[doc = " Instruction's operand referring to memory\n This is associated with SYSZ_OP_MEM operand type above"]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct sysz_op_mem {
     #[doc = "< base register, can be safely interpreted as\n< a value of type `sysz_reg`, but it is only\n< one byte wide"]
     pub base: u8,
@@ -8555,21 +8487,16 @@ pub struct sysz_op_mem {
     #[doc = "< displacement/offset value"]
     pub disp: i64,
 }
-impl Clone for sysz_op_mem {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[doc = " Instruction operand"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_sysz_op {
     #[doc = "< operand type"]
     pub type_: sysz_op_type,
     pub __bindgen_anon_1: cs_sysz_op__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_sysz_op__bindgen_ty_1 {
     #[doc = "< register value for REG operand"]
     pub reg: sysz_reg::Type,
@@ -8578,19 +8505,9 @@ pub union cs_sysz_op__bindgen_ty_1 {
     #[doc = "< base/disp value for MEM operand"]
     pub mem: sysz_op_mem,
 }
-impl Clone for cs_sysz_op__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_sysz_op__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_sysz_op__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for cs_sysz_op {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_sysz_op {
@@ -8603,7 +8520,7 @@ impl ::core::fmt::Debug for cs_sysz_op {
     }
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_sysz {
     #[doc = "< Code condition"]
     pub cc: sysz_cc,
@@ -8611,11 +8528,6 @@ pub struct cs_sysz {
     pub op_count: u8,
     #[doc = "< operands for this instruction."]
     pub operands: [cs_sysz_op; 6usize],
-}
-impl Clone for cs_sysz {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl ::core::fmt::Debug for cs_sysz {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -11379,7 +11291,9 @@ pub enum x86_avx_rm {
     #[doc = "< Round toward zero"]
     X86_AVX_RM_RZ = 4,
 }
-pub const X86_PREFIX_REPE: x86_prefix = x86_prefix::X86_PREFIX_REP;
+impl x86_prefix {
+    pub const X86_PREFIX_REPE: x86_prefix = x86_prefix::X86_PREFIX_REP;
+}
 #[repr(u32)]
 #[doc = " Instruction prefixes - to be used in cs_x86.prefix[]"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -11409,7 +11323,7 @@ pub enum x86_prefix {
 }
 #[doc = " Instruction's operand referring to memory\n This is associated with X86_OP_MEM operand type above"]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct x86_op_mem {
     #[doc = "< segment register (or X86_REG_INVALID if irrelevant)"]
     pub segment: x86_reg::Type,
@@ -11422,14 +11336,9 @@ pub struct x86_op_mem {
     #[doc = "< displacement value"]
     pub disp: i64,
 }
-impl Clone for x86_op_mem {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[doc = " Instruction operand"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_x86_op {
     #[doc = "< operand type"]
     pub type_: x86_op_type,
@@ -11444,7 +11353,7 @@ pub struct cs_x86_op {
     pub avx_zero_opmask: bool,
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_x86_op__bindgen_ty_1 {
     #[doc = "< register value for REG operand"]
     pub reg: x86_reg::Type,
@@ -11453,19 +11362,9 @@ pub union cs_x86_op__bindgen_ty_1 {
     #[doc = "< base/index/scale/disp value for MEM operand"]
     pub mem: x86_op_mem,
 }
-impl Clone for cs_x86_op__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_x86_op__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_x86_op__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for cs_x86_op {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_x86_op {
@@ -11474,7 +11373,7 @@ impl ::core::fmt::Debug for cs_x86_op {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct cs_x86_encoding {
     #[doc = " ModR/M offset, or 0 when irrelevant"]
     pub modrm_offset: u8,
@@ -11485,14 +11384,9 @@ pub struct cs_x86_encoding {
     pub imm_offset: u8,
     pub imm_size: u8,
 }
-impl Clone for cs_x86_encoding {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[doc = " Instruction structure"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_x86 {
     #[doc = " Instruction prefix, which can be up to 4 bytes.\n A prefix byte gets value 0 when irrelevant.\n prefix[0] indicates REP/REPNE/LOCK prefix (See X86_PREFIX_REP/REPNE/LOCK above)\n prefix[1] indicates segment override (irrelevant for x86_64):\n See X86_PREFIX_CS/SS/DS/ES/FS/GS above.\n prefix[2] indicates operand-size override (X86_PREFIX_OPSIZE)\n prefix[3] indicates address-size override (X86_PREFIX_ADDRSIZE)"]
     pub prefix: [u8; 4usize],
@@ -11533,26 +11427,16 @@ pub struct cs_x86 {
     pub encoding: cs_x86_encoding,
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_x86__bindgen_ty_1 {
     #[doc = " EFLAGS updated by this instruction.\n This can be formed from OR combination of X86_EFLAGS_* symbols in x86.h"]
     pub eflags: u64,
     #[doc = " FPU_FLAGS updated by this instruction.\n This can be formed from OR combination of X86_FPU_FLAGS_* symbols in x86.h"]
     pub fpu_flags: u64,
 }
-impl Clone for cs_x86__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_x86__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_x86__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for cs_x86 {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_x86 {
@@ -13202,7 +13086,7 @@ pub mod xcore_reg {
 }
 #[doc = " Instruction's operand referring to memory\n This is associated with XCORE_OP_MEM operand type above"]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct xcore_op_mem {
     #[doc = "< base register, can be safely interpreted as\n< a value of type `xcore_reg`, but it is only\n< one byte wide"]
     pub base: u8,
@@ -13213,21 +13097,16 @@ pub struct xcore_op_mem {
     #[doc = "< +1: forward, -1: backward"]
     pub direct: libc::c_int,
 }
-impl Clone for xcore_op_mem {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[doc = " Instruction operand"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_xcore_op {
     #[doc = "< operand type"]
     pub type_: xcore_op_type,
     pub __bindgen_anon_1: cs_xcore_op__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_xcore_op__bindgen_ty_1 {
     #[doc = "< register value for REG operand"]
     pub reg: xcore_reg::Type,
@@ -13236,19 +13115,9 @@ pub union cs_xcore_op__bindgen_ty_1 {
     #[doc = "< base/disp value for MEM operand"]
     pub mem: xcore_op_mem,
 }
-impl Clone for cs_xcore_op__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_xcore_op__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_xcore_op__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for cs_xcore_op {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_xcore_op {
@@ -13262,17 +13131,12 @@ impl ::core::fmt::Debug for cs_xcore_op {
 }
 #[doc = " Instruction structure"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_xcore {
     #[doc = " Number of operands of this instruction,\n or 0 when instruction has no operand."]
     pub op_count: u8,
     #[doc = "< operands for this instruction."]
     pub operands: [cs_xcore_op; 8usize],
-}
-impl Clone for cs_xcore {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl ::core::fmt::Debug for cs_xcore {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -13452,7 +13316,7 @@ pub enum tms320c64x_mem_mod {
     TMS320C64X_MEM_MOD_POST = 3,
 }
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct tms320c64x_op_mem {
     #[doc = "< base register"]
     pub base: libc::c_uint,
@@ -13469,20 +13333,15 @@ pub struct tms320c64x_op_mem {
     #[doc = "< modification"]
     pub modify: libc::c_uint,
 }
-impl Clone for tms320c64x_op_mem {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_tms320c64x_op {
     #[doc = "< operand type"]
     pub type_: tms320c64x_op_type,
     pub __bindgen_anon_1: cs_tms320c64x_op__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_tms320c64x_op__bindgen_ty_1 {
     #[doc = "< register value for REG operand or first register for REGPAIR operand"]
     pub reg: libc::c_uint,
@@ -13491,19 +13350,9 @@ pub union cs_tms320c64x_op__bindgen_ty_1 {
     #[doc = "< base/disp value for MEM operand"]
     pub mem: tms320c64x_op_mem,
 }
-impl Clone for cs_tms320c64x_op__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_tms320c64x_op__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_tms320c64x_op__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for cs_tms320c64x_op {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_tms320c64x_op {
@@ -13516,7 +13365,7 @@ impl ::core::fmt::Debug for cs_tms320c64x_op {
     }
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_tms320c64x {
     pub op_count: u8,
     #[doc = "< operands for this instruction."]
@@ -13526,32 +13375,17 @@ pub struct cs_tms320c64x {
     pub parallel: libc::c_uint,
 }
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct cs_tms320c64x__bindgen_ty_1 {
     pub reg: libc::c_uint,
     pub zero: libc::c_uint,
 }
-impl Clone for cs_tms320c64x__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct cs_tms320c64x__bindgen_ty_2 {
     pub unit: libc::c_uint,
     pub side: libc::c_uint,
     pub crosspath: libc::c_uint,
-}
-impl Clone for cs_tms320c64x__bindgen_ty_2 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Clone for cs_tms320c64x {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl ::core::fmt::Debug for cs_tms320c64x {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -13903,7 +13737,7 @@ pub enum m680x_op_type {
 }
 #[doc = " Instruction's operand referring to indexed addressing"]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct m680x_op_idx {
     #[doc = "< base register (or M680X_REG_INVALID if\n< irrelevant)"]
     pub base_reg: m680x_reg::Type,
@@ -13920,42 +13754,27 @@ pub struct m680x_op_idx {
     #[doc = "< 8-bit flags (see above)"]
     pub flags: u8,
 }
-impl Clone for m680x_op_idx {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[doc = " Instruction's memory operand referring to relative addressing (Bcc/LBcc)"]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct m680x_op_rel {
     #[doc = "< The absolute address.\n< calculated as PC + offset. PC is the first\n< address after the instruction."]
     pub address: u16,
     #[doc = "< the offset/displacement value"]
     pub offset: i16,
 }
-impl Clone for m680x_op_rel {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[doc = " Instruction's operand referring to extended addressing"]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct m680x_op_ext {
     #[doc = "< The absolute address"]
     pub address: u16,
     #[doc = "< true if extended indirect addressing"]
     pub indirect: bool,
 }
-impl Clone for m680x_op_ext {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[doc = " Instruction operand"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_m680x_op {
     pub type_: m680x_op_type,
     pub __bindgen_anon_1: cs_m680x_op__bindgen_ty_1,
@@ -13965,7 +13784,7 @@ pub struct cs_m680x_op {
     pub access: u8,
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_m680x_op__bindgen_ty_1 {
     #[doc = "< immediate value for IMM operand"]
     pub imm: i32,
@@ -13982,19 +13801,9 @@ pub union cs_m680x_op__bindgen_ty_1 {
     #[doc = "< constant value (bit index, page nr.)"]
     pub const_val: u8,
 }
-impl Clone for cs_m680x_op__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_m680x_op__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_m680x_op__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for cs_m680x_op {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_m680x_op {
@@ -14029,7 +13838,7 @@ pub enum m680x_group_type {
 }
 #[doc = " The M680X instruction and it's operands"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_m680x {
     #[doc = "< See: M680X instruction flags"]
     pub flags: u8,
@@ -14037,11 +13846,6 @@ pub struct cs_m680x {
     pub op_count: u8,
     #[doc = "< operands for this insn."]
     pub operands: [cs_m680x_op; 9usize],
-}
-impl Clone for cs_m680x {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl ::core::fmt::Debug for cs_m680x {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -14450,7 +14254,7 @@ pub enum m680x_insn {
 }
 #[doc = " Instruction structure"]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct cs_evm {
     #[doc = "< number of items popped from the stack"]
     pub pop: libc::c_uchar,
@@ -14458,11 +14262,6 @@ pub struct cs_evm {
     pub push: libc::c_uchar,
     #[doc = "< gas fee for the instruction"]
     pub fee: libc::c_uint,
-}
-impl Clone for cs_evm {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 #[repr(u32)]
 #[doc = " EVM instruction"]
@@ -14641,42 +14440,27 @@ pub enum riscv_op_type {
     RISCV_OP_MEM = 3,
 }
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct riscv_op_mem {
     pub base: libc::c_uint,
     pub disp: i64,
 }
-impl Clone for riscv_op_mem {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_riscv_op {
     pub type_: riscv_op_type,
     pub __bindgen_anon_1: cs_riscv_op__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_riscv_op__bindgen_ty_1 {
     pub reg: libc::c_uint,
     pub imm: i64,
     pub mem: riscv_op_mem,
 }
-impl Clone for cs_riscv_op__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_riscv_op__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_riscv_op__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for cs_riscv_op {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_riscv_op {
@@ -14689,16 +14473,11 @@ impl ::core::fmt::Debug for cs_riscv_op {
     }
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_riscv {
     pub need_effective_addr: bool,
     pub op_count: u8,
     pub operands: [cs_riscv_op; 8usize],
-}
-impl Clone for cs_riscv {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl ::core::fmt::Debug for cs_riscv {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -15148,26 +14927,21 @@ pub enum wasm_op_type {
     WASM_OP_BRTABLE = 8,
 }
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct cs_wasm_brtable {
     pub length: u32,
     pub address: u64,
     pub default_target: u32,
 }
-impl Clone for cs_wasm_brtable {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_wasm_op {
     pub type_: wasm_op_type,
     pub size: u32,
     pub __bindgen_anon_1: cs_wasm_op__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_wasm_op__bindgen_ty_1 {
     pub int7: i8,
     pub varuint32: u32,
@@ -15177,19 +14951,9 @@ pub union cs_wasm_op__bindgen_ty_1 {
     pub immediate: [u32; 2usize],
     pub brtable: cs_wasm_brtable,
 }
-impl Clone for cs_wasm_op__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_wasm_op__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_wasm_op__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for cs_wasm_op {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_wasm_op {
@@ -15203,15 +14967,10 @@ impl ::core::fmt::Debug for cs_wasm_op {
 }
 #[doc = " Instruction structure"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_wasm {
     pub op_count: u8,
     pub operands: [cs_wasm_op; 2usize],
-}
-impl Clone for cs_wasm {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl ::core::fmt::Debug for cs_wasm {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -15313,14 +15072,14 @@ pub enum mos65xx_op_type {
 }
 #[doc = " Instruction operand"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_mos65xx_op {
     #[doc = "< operand type"]
     pub type_: mos65xx_op_type,
     pub __bindgen_anon_1: cs_mos65xx_op__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_mos65xx_op__bindgen_ty_1 {
     #[doc = "< register value for REG operand"]
     pub reg: mos65xx_reg,
@@ -15329,19 +15088,9 @@ pub union cs_mos65xx_op__bindgen_ty_1 {
     #[doc = "< address for MEM operand"]
     pub mem: u32,
 }
-impl Clone for cs_mos65xx_op__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_mos65xx_op__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_mos65xx_op__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for cs_mos65xx_op {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_mos65xx_op {
@@ -15355,7 +15104,7 @@ impl ::core::fmt::Debug for cs_mos65xx_op {
 }
 #[doc = " The MOS65XX address mode and it's operands"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_mos65xx {
     pub am: mos65xx_address_mode,
     pub modifies_flags: bool,
@@ -15363,11 +15112,6 @@ pub struct cs_mos65xx {
     pub op_count: u8,
     #[doc = "< operands for this instruction."]
     pub operands: [cs_mos65xx_op; 3usize],
-}
-impl Clone for cs_mos65xx {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl ::core::fmt::Debug for cs_mos65xx {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -15415,17 +15159,12 @@ pub mod bpf_reg {
 }
 #[doc = " Instruction's operand referring to memory\n This is associated with BPF_OP_MEM operand type above"]
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct bpf_op_mem {
     #[doc = "< base register"]
     pub base: bpf_reg::Type,
     #[doc = "< offset value"]
     pub disp: u32,
-}
-impl Clone for bpf_op_mem {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -15435,7 +15174,7 @@ pub enum bpf_ext_type {
 }
 #[doc = " Instruction operand"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_bpf_op {
     pub type_: bpf_op_type,
     pub __bindgen_anon_1: cs_bpf_op__bindgen_ty_1,
@@ -15443,7 +15182,7 @@ pub struct cs_bpf_op {
     pub access: u8,
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_bpf_op__bindgen_ty_1 {
     #[doc = "< register value for REG operand"]
     pub reg: u8,
@@ -15460,19 +15199,9 @@ pub union cs_bpf_op__bindgen_ty_1 {
     #[doc = "< cBPF's extension (not eBPF)"]
     pub ext: u32,
 }
-impl Clone for cs_bpf_op__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_bpf_op__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_bpf_op__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for cs_bpf_op {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_bpf_op {
@@ -15486,25 +15215,28 @@ impl ::core::fmt::Debug for cs_bpf_op {
 }
 #[doc = " Instruction structure"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_bpf {
     pub op_count: u8,
     pub operands: [cs_bpf_op; 4usize],
-}
-impl Clone for cs_bpf {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl ::core::fmt::Debug for cs_bpf {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_bpf {{ operands: {:?} }}", self.operands)
     }
 }
-pub const BPF_INS_LD: bpf_insn = bpf_insn::BPF_INS_LDW;
-pub const BPF_INS_LDX: bpf_insn = bpf_insn::BPF_INS_LDXW;
-pub const BPF_INS_ST: bpf_insn = bpf_insn::BPF_INS_STW;
-pub const BPF_INS_STX: bpf_insn = bpf_insn::BPF_INS_STXW;
+impl bpf_insn {
+    pub const BPF_INS_LD: bpf_insn = bpf_insn::BPF_INS_LDW;
+}
+impl bpf_insn {
+    pub const BPF_INS_LDX: bpf_insn = bpf_insn::BPF_INS_LDXW;
+}
+impl bpf_insn {
+    pub const BPF_INS_ST: bpf_insn = bpf_insn::BPF_INS_STW;
+}
+impl bpf_insn {
+    pub const BPF_INS_STX: bpf_insn = bpf_insn::BPF_INS_STXW;
+}
 #[repr(u32)]
 #[doc = " BPF instruction"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -15624,7 +15356,7 @@ pub mod bpf_insn_group {
 }
 #[doc = " NOTE: All information in cs_detail is only available when CS_OPT_DETAIL = CS_OPT_ON\n Initialized as memset(., 0, offsetof(cs_detail, ARCH)+sizeof(cs_ARCH))\n by ARCH_getInstruction in arch/ARCH/ARCHDisassembler.c\n if cs_detail changes, in particular if a field is added after the union,\n then update arch/ARCH/ARCHDisassembler.c accordingly"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct cs_detail {
     #[doc = "< list of implicit registers read by this insn"]
     pub regs_read: [u16; 16usize],
@@ -15642,7 +15374,7 @@ pub struct cs_detail {
 }
 #[doc = " Architecture-specific instruction info"]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub union cs_detail__bindgen_ty_1 {
     #[doc = "< X86 architecture, including 16-bit, 32-bit & 64-bit mode"]
     pub x86: cs_x86,
@@ -15677,19 +15409,9 @@ pub union cs_detail__bindgen_ty_1 {
     #[doc = "< RISCV architecture"]
     pub riscv: cs_riscv,
 }
-impl Clone for cs_detail__bindgen_ty_1 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 impl ::core::fmt::Debug for cs_detail__bindgen_ty_1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "cs_detail__bindgen_ty_1 {{ union }}")
-    }
-}
-impl Clone for cs_detail {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 impl ::core::fmt::Debug for cs_detail {
@@ -15867,15 +15589,10 @@ extern "C" {
 }
 pub type __builtin_va_list = [__va_list_tag; 1usize];
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct __va_list_tag {
     pub gp_offset: libc::c_uint,
     pub fp_offset: libc::c_uint,
     pub overflow_arg_area: *mut libc::c_void,
     pub reg_save_area: *mut libc::c_void,
-}
-impl Clone for __va_list_tag {
-    fn clone(&self) -> Self {
-        *self
-    }
 }


### PR DESCRIPTION
capstone-rs crashes on s390x (also knows as SystemZ in the LLVM world)
as follows:

    Thread 2 received signal SIGSEGV, Segmentation fault.
    0x000002aa00a6a604 in cs_option (ud=140702726002672, type=CS_OPT_SYNTAX, value=2) at capstone/cs.c:782
    782             return arch_configs[handle->arch].arch_option(handle, type, value);

    (gdb) p/x handle->arch
    $7 = 0x7ffb

handle->arch is clearly corrupted. It is assigned as follows in
cs_open():

       0x000002aa00a6a44a <+146>:   lgr     %r9,%r3
    [...]
       0x000002aa00a6a468 <+176>:   rosbg   %r9,%r10,0,31,32
    [...]
    458                     ud->arch = arch;
    459                     ud->mode = mode;
       0x000002aa00a6a47a <+194>:   stg     %r9,0(%r13)

Here the 32-bit arch value and the 32-bit mode value are placed into a
64-bit register and stored with one instruction.

The important part is that cs_mode is a 32-bit value passed in %r3, and
the code uses instructions with mnemonics ending with "g", which
operate on full 64-bit registers [1]. This is allowed because of the
s390x ABI [1]: it requires zero-extension of 4-byte int arguments.

Bitfield enums are currently generated like this:

    #[repr(C)]
    [...]
    pub struct cs_mode(pub libc::c_uint);

which causes the problem above, because the ABI does not require
zero-extension of 4-byte struct arguments.

Starting from RustTarget::Stable_1_28, bindgen
generates #[repr(transparent)] instead of #[repr(C)], which is
designed to solve exactly this kind of problems [3].

capstone-rs' MSRV is 1.70, so it should be possible to go even further,
but be conservative and use the minimum version necessary to fix the
issue.

[1] https://publibfp.dhe.ibm.com/epubs/pdf/a227832d.pdf
[2] https://github.com/IBM/s390x-abi/releases
[3] https://doc.rust-lang.org/nomicon/other-reprs.html#reprtransparent
