### PR TITLE
Fix accidentally forced std/allocator on no_std

### DIFF
--- a/capstone-rs/src/lib.rs
+++ b/capstone-rs/src/lib.rs
@@ -8,11 +8,11 @@
 #[macro_use]
 extern crate alloc;
 
-#[cfg(any(test, not(feature = "std")))]
+#[cfg(all(test, not(feature = "std")))]
 #[macro_use]
 extern crate std;
 
-#[cfg(any(test, not(feature = "std")))]
+#[cfg(all(test, not(feature = "std")))]
 #[global_allocator]
 static ALLOCATOR: std::alloc::System = std::alloc::System;
 


### PR DESCRIPTION
The `cfg` config for `std`/`ALLOCATOR` might be accidentally too permissive.

Specifically, as it currently stands:
```rs
#[cfg(any(test, not(feature = "std")))]
#[macro_use]
extern crate std;
```
This code brings in `std` even if the feature `std` is not enabled (because `any` would hold true if even one of the two conditions is true). Similarly, for `ALLOCATOR`.

By changing it to `all` instead of `any`, it is only applicable for tests for non-`std` configuration, which is what I believe the intention is here.