### PR TITLE
Make `build.rs` compatible with Bazel's sandbox

### DIFF
--- a/capstone-sys/build.rs
+++ b/capstone-sys/build.rs
@@ -91,7 +91,7 @@ fn build_capstone_cc() {
                 .file_type()
                 .expect("Failed to read capstone source directory");
             let file_name = e.file_name().into_string().expect("Invalid filename");
-            file_type.is_file() && (file_name.ends_with(".c") || file_name.ends_with(".C"))
+            !file_type.is_dir() && (file_name.ends_with(".c") || file_name.ends_with(".C"))
         })
     }
 


### PR DESCRIPTION
When building with Bazel's sandbox, all the capstone source files are actually symlinks. In this case `build.rs` doesn't find any files to build and attempts to link the static library right away.

Reproducer and the error messages can be found [here](https://github.com/bazelbuild/rules_rust/issues/3435).
I tested the change locally on macOS with the following spec:
```bazel
crate.spec(
    package = "capstone-sys",
    git = "https://github.com/AlexDenisov/capstone-rs.git",
    branch = "bazel-compatibility",
)
```
which is working as expected.

Is there anything else I'd need to check to ensure this change doesn't break anything?
