### PR TITLE
rs: rename RegAccessType to AccessType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Arch-specific features flags to enable/disable arch support
 - Expose X86 instruction encoding info via `X86InsnDetail::encoding()`
 - Make RegAccessType available for ARM64
+- Rename RegAccessType to AccessType while keeping type alias
 
 ### Changed
 - `InsnDetail::regs_read()`/`InsnDetail::regs_write()` return more of the accessed registers

--- a/capstone-rs/src/arch/arm.rs
+++ b/capstone-rs/src/arch/arm.rs
@@ -10,7 +10,7 @@ use libc::c_uint;
 pub use crate::arch::arch_builder::arm::*;
 use crate::arch::DetailsArchInsn;
 use crate::instruction::{RegId, RegIdInt};
-use crate::RegAccessType;
+use crate::AccessType;
 
 pub use capstone_sys::arm_insn_group as ArmInsnGroup;
 pub use capstone_sys::arm_insn as ArmInsn;
@@ -133,7 +133,7 @@ pub struct ArmOperand {
     /// How is this operand accessed?
     ///
     /// NOTE: this field is always `None` if the "full" feataure is not enabled.
-    pub access: Option<RegAccessType>
+    pub access: Option<AccessType>
 }
 
 /// ARM operand

--- a/capstone-rs/src/arch/arm64.rs
+++ b/capstone-rs/src/arch/arm64.rs
@@ -4,7 +4,7 @@ use libc::c_uint;
 
 pub use crate::arch::arch_builder::arm64::*;
 use crate::arch::DetailsArchInsn;
-use crate::instruction::{RegAccessType, RegId, RegIdInt};
+use crate::instruction::{AccessType, RegId, RegIdInt};
 use capstone_sys::{arm64_op_mem, arm64_op_sme_index, arm64_op_type, cs_ac_type, cs_arm64, cs_arm64_op};
 use core::convert::{From, TryInto};
 use core::{cmp, fmt, mem, slice};
@@ -89,7 +89,7 @@ pub struct Arm64Operand {
     /// How is this operand accessed?
     ///
     /// NOTE: this field is always `None` if the "full" feataure is not enabled.
-    pub access: Option<RegAccessType>,
+    pub access: Option<AccessType>,
 
     /// Vector Index for some vector operands
     pub vector_index: Option<u32>,

--- a/capstone-rs/src/arch/x86.rs
+++ b/capstone-rs/src/arch/x86.rs
@@ -21,7 +21,7 @@ use capstone_sys::{
 use super::InsnOffsetSpan;
 pub use crate::arch::arch_builder::x86::*;
 use crate::arch::DetailsArchInsn;
-use crate::instruction::{RegAccessType, RegId, RegIdInt};
+use crate::instruction::{AccessType, RegId, RegIdInt};
 
 /// Contains X86-specific details for an instruction
 pub struct X86InsnDetail<'a>(pub(crate) &'a cs_x86);
@@ -51,7 +51,7 @@ pub struct X86Operand {
     /// How is this operand accessed?
     ///
     /// NOTE: this field is always `None` if the "full" feataure is not enabled.
-    pub access: Option<RegAccessType>,
+    pub access: Option<AccessType>,
 
     /// AVX broadcast
     pub avx_bcast: X86AvxBcast,

--- a/capstone-rs/src/instruction.rs
+++ b/capstone-rs/src/instruction.rs
@@ -66,9 +66,9 @@ impl RegId {
     pub const INVALID_REG: Self = Self(0);
 }
 
-/// Represents how the register is accessed.
+/// Represents how the operand is accessed.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
-pub enum RegAccessType {
+pub enum AccessType {
     /// Operand read from memory or register.
     ReadOnly,
     /// Operand write from memory or register.
@@ -77,14 +77,14 @@ pub enum RegAccessType {
     ReadWrite,
 }
 
-impl RegAccessType {
+impl AccessType {
     /// Returns whether the instruction reads from the operand.
     ///
     /// Note that an instruction may read and write to the register
     /// simultaneously. In this case, the operand is also considered as
     /// readable.
     pub fn is_readable(self) -> bool {
-        self == RegAccessType::ReadOnly || self == RegAccessType::ReadWrite
+        self == AccessType::ReadOnly || self == AccessType::ReadWrite
     }
 
     /// Returns whether the instruction writes from the operand.
@@ -93,11 +93,11 @@ impl RegAccessType {
     /// simultaneously. In this case, the operand is also considered as
     /// writable.
     pub fn is_writable(self) -> bool {
-        self == RegAccessType::WriteOnly || self == RegAccessType::ReadWrite
+        self == AccessType::WriteOnly || self == AccessType::ReadWrite
     }
 }
 
-impl TryFrom<cs_ac_type> for RegAccessType {
+impl TryFrom<cs_ac_type> for AccessType {
     type Error = ();
 
     fn try_from(access: cs_ac_type) -> Result<Self, Self::Error> {
@@ -110,13 +110,17 @@ impl TryFrom<cs_ac_type> for RegAccessType {
         let is_readable = (access & cs_ac_type::CS_AC_READ).0 != 0;
         let is_writable = (access & cs_ac_type::CS_AC_WRITE).0 != 0;
         match (is_readable, is_writable) {
-            (true, false) => Ok(RegAccessType::ReadOnly),
-            (false, true) => Ok(RegAccessType::WriteOnly),
-            (true, true) => Ok(RegAccessType::ReadWrite),
+            (true, false) => Ok(AccessType::ReadOnly),
+            (false, true) => Ok(AccessType::WriteOnly),
+            (true, true) => Ok(AccessType::ReadWrite),
             _ => Err(()),
         }
     }
 }
+
+/// Previously the enum was called RegAccessType, see issue #135
+/// Maintain compatibility with legacy code
+pub type RegAccessType = AccessType;
 
 impl<'a> Instructions<'a> {
     pub(crate) unsafe fn from_raw_parts(ptr: *mut cs_insn, len: usize) -> Instructions<'a> {

--- a/capstone-rs/src/test.rs
+++ b/capstone-rs/src/test.rs
@@ -948,12 +948,12 @@ fn test_arch_arm_detail() {
 
     let r0_op_read = ArmOperand {
         op_type: Reg(RegId(ArmReg::ARM_REG_R0 as RegIdInt)),
-        access: Some(RegAccessType::ReadOnly),
+        access: Some(AccessType::ReadOnly),
         ..Default::default()
     };
     let r0_op_write = ArmOperand {
         op_type: Reg(RegId(ArmReg::ARM_REG_R0 as RegIdInt)),
-        access: Some(RegAccessType::WriteOnly),
+        access: Some(AccessType::WriteOnly),
         ..Default::default()
     };
 
@@ -984,7 +984,7 @@ fn test_arch_arm_detail() {
                 &[
                     ArmOperand {
                         op_type: Reg(RegId(ArmReg::ARM_REG_LR as RegIdInt)),
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         ..Default::default()
                     },
                     ArmOperand {
@@ -995,7 +995,7 @@ fn test_arch_arm_detail() {
                             disp: -4,
                             lshift: 0,
                         })),
-                        access: Some(RegAccessType::WriteOnly),
+                        access: Some(AccessType::WriteOnly),
                         ..Default::default()
                     },
                 ],
@@ -1013,7 +1013,7 @@ fn test_arch_arm_detail() {
                 &[
                     ArmOperand {
                         op_type: Reg(RegId(ArmReg::ARM_REG_R8 as RegIdInt)),
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         ..Default::default()
                     },
                     ArmOperand {
@@ -1024,7 +1024,7 @@ fn test_arch_arm_detail() {
                             disp: -992,
                             lshift: 0,
                         })),
-                        access: Some(RegAccessType::WriteOnly),
+                        access: Some(AccessType::WriteOnly),
                         ..Default::default()
                     },
                 ],
@@ -1087,7 +1087,7 @@ fn test_arch_arm_detail() {
             b"\x70\x47",
             &[ArmOperand {
                 op_type: Reg(RegId(ArmReg::ARM_REG_LR as RegIdInt)),
-                access: Some(RegAccessType::ReadOnly),
+                access: Some(AccessType::ReadOnly),
                 ..Default::default()
             }],
         )],
@@ -1192,12 +1192,12 @@ fn test_arch_arm64_detail() {
                 b"\xbf\x40\x00\xd5",
                 &[
                     Arm64Operand {
-                        access: Some(RegAccessType::WriteOnly),
+                        access: Some(AccessType::WriteOnly),
                         op_type: Pstate(ARM64_PSTATE_SPSEL),
                         ..Default::default()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         op_type: Imm(0),
                         ..Default::default()
                     },
@@ -1209,25 +1209,25 @@ fn test_arch_arm64_detail() {
                 b"\x20\x50\x02\x0e",
                 &[
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadWrite),
+                        access: Some(AccessType::ReadWrite),
                         vas: ARM64_VAS_8B,
                         op_type: Reg(RegId(ARM64_REG_V0 as RegIdInt)),
                         ..Default::default()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         vas: ARM64_VAS_16B,
                         op_type: Reg(RegId(ARM64_REG_V1 as RegIdInt)),
                         ..Default::default()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         vas: ARM64_VAS_16B,
                         op_type: Reg(RegId(ARM64_REG_V2 as RegIdInt)),
                         ..Default::default()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         vas: ARM64_VAS_16B,
                         op_type: Reg(RegId(ARM64_REG_V3 as RegIdInt)),
                         ..Default::default()
@@ -1245,19 +1245,19 @@ fn test_arch_arm64_detail() {
                 b"\x20\xe4\x3d\x0f",
                 &[
                     Arm64Operand {
-                        access: Some(RegAccessType::WriteOnly),
+                        access: Some(AccessType::WriteOnly),
                         vas: ARM64_VAS_2S,
                         op_type: Reg(RegId(ARM64_REG_V0 as RegIdInt)),
                         ..Default::default()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         vas: ARM64_VAS_2S,
                         op_type: Reg(RegId(ARM64_REG_V1 as RegIdInt)),
                         ..Default::default()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         op_type: Imm(3),
                         ..Default::default()
                     },
@@ -1269,15 +1269,15 @@ fn test_arch_arm64_detail() {
                 b"\x00\x18\xa0\x5f",
                 &[
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadWrite),
+                        access: Some(AccessType::ReadWrite),
                         ..s0.clone()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         ..s0
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         vector_index: Some(3),
                         op_type: Reg(RegId(ARM64_REG_V0 as RegIdInt)),
                         vas: ARM64_VAS_1S,
@@ -1291,11 +1291,11 @@ fn test_arch_arm64_detail() {
                 b"\xa2\x00\xae\x9e",
                 &[
                     Arm64Operand {
-                        access: Some(RegAccessType::WriteOnly),
+                        access: Some(AccessType::WriteOnly),
                         ..x2.clone()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         vector_index: Some(1),
                         op_type: Reg(RegId(ARM64_REG_V5 as RegIdInt)),
                         vas: ARM64_VAS_INVALID, // should be ARM64_VAS_1D instead?
@@ -1308,7 +1308,7 @@ fn test_arch_arm64_detail() {
                 "dsb",
                 b"\x9f\x37\x03\xd5",
                 &[Arm64Operand {
-                    access: Some(RegAccessType::ReadOnly),
+                    access: Some(AccessType::ReadOnly),
                     op_type: Barrier(Arm64BarrierOp::ARM64_BARRIER_NSH),
                     ..Default::default()
                 }],
@@ -1318,7 +1318,7 @@ fn test_arch_arm64_detail() {
                 "dmb",
                 b"\xbf\x33\x03\xd5",
                 &[Arm64Operand {
-                    access: Some(RegAccessType::ReadOnly),
+                    access: Some(AccessType::ReadOnly),
                     op_type: Barrier(Arm64BarrierOp::ARM64_BARRIER_OSH),
                     ..Default::default()
                 }],
@@ -1331,15 +1331,15 @@ fn test_arch_arm64_detail() {
                 b"\x21\x7c\x02\x9b",
                 &[
                     Arm64Operand {
-                        access: Some(RegAccessType::WriteOnly),
+                        access: Some(AccessType::WriteOnly),
                         ..x1.clone()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         ..x1.clone()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         ..x2.clone()
                     },
                 ],
@@ -1351,17 +1351,17 @@ fn test_arch_arm64_detail() {
                 &[
                     Arm64Operand {
                         // Upstream bug: should be read only, fixed in capstone v6
-                        access: Some(RegAccessType::ReadWrite),
+                        access: Some(AccessType::ReadWrite),
                         op_type: Reg(RegId(ARM64_REG_W1 as RegIdInt)),
                         ..Default::default()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         op_type: Reg(RegId(ARM64_REG_W1 as RegIdInt)),
                         ..Default::default()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         op_type: Imm(0),
                         ..Default::default()
                     },
@@ -1373,17 +1373,17 @@ fn test_arch_arm64_detail() {
                 b"\x00\x40\x21\x4b",
                 &[
                     Arm64Operand {
-                        access: Some(RegAccessType::WriteOnly),
+                        access: Some(AccessType::WriteOnly),
                         op_type: Reg(RegId(ARM64_REG_W0 as RegIdInt)),
                         ..Default::default()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         op_type: Reg(RegId(ARM64_REG_W0 as RegIdInt)),
                         ..Default::default()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         ext: Arm64Extender::ARM64_EXT_UXTW,
                         op_type: Reg(RegId(ARM64_REG_W1 as RegIdInt)),
                         ..Default::default()
@@ -1396,12 +1396,12 @@ fn test_arch_arm64_detail() {
                 b"\xe1\x0b\x40\xb9",
                 &[
                     Arm64Operand {
-                        access: Some(RegAccessType::WriteOnly),
+                        access: Some(AccessType::WriteOnly),
                         op_type: Reg(RegId(ARM64_REG_W1 as RegIdInt)),
                         ..Default::default()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         op_type: Mem(Arm64OpMem(arm64_op_mem {
                             base: ARM64_REG_SP,
                             index: 0,
@@ -1417,11 +1417,11 @@ fn test_arch_arm64_detail() {
                 b"\x20\x04\x81\xda",
                 &[
                     Arm64Operand {
-                        access: Some(RegAccessType::WriteOnly),
+                        access: Some(AccessType::WriteOnly),
                         ..x0.clone()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         ..x1.clone()
                     },
                 ],
@@ -1432,15 +1432,15 @@ fn test_arch_arm64_detail() {
                 b"\x20\x08\x02\x8b",
                 &[
                     Arm64Operand {
-                        access: Some(RegAccessType::WriteOnly),
+                        access: Some(AccessType::WriteOnly),
                         ..x0
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         ..x1
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         shift: Arm64Shift::Lsl(2),
                         ..x2
                     },
@@ -1452,12 +1452,12 @@ fn test_arch_arm64_detail() {
                 b"\x10\x5b\xe8\x3c",
                 &[
                     Arm64Operand {
-                        access: Some(RegAccessType::WriteOnly),
+                        access: Some(AccessType::WriteOnly),
                         op_type: Reg(RegId(ARM64_REG_Q16 as RegIdInt)),
                         ..Default::default()
                     },
                     Arm64Operand {
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         shift: Arm64Shift::Lsl(4),
                         ext: Arm64Extender::ARM64_EXT_UXTW,
                         op_type: Mem(Arm64OpMem(arm64_op_mem {
@@ -3398,13 +3398,13 @@ fn test_arch_x86_detail() {
                 &[
                     X86Operand {
                         size: 2,
-                        access: Some(RegAccessType::WriteOnly),
+                        access: Some(AccessType::WriteOnly),
                         op_type: Reg(RegId(X86_REG_CX as RegIdInt)),
                         ..Default::default()
                     },
                     X86Operand {
                         size: 2,
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         op_type: Mem(X86OpMem(x86_op_mem {
                             segment: 0,
                             base: X86_REG_SI,
@@ -3423,7 +3423,7 @@ fn test_arch_x86_detail() {
                 &[
                     X86Operand {
                         size: 1,
-                        access: Some(RegAccessType::ReadWrite),
+                        access: Some(AccessType::ReadWrite),
                         op_type: Mem(X86OpMem(x86_op_mem {
                             segment: 0,
                             base: X86_REG_BX,
@@ -3435,7 +3435,7 @@ fn test_arch_x86_detail() {
                     },
                     X86Operand {
                         size: 1,
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         op_type: Reg(RegId(X86_REG_AL as RegIdInt)),
                         ..Default::default()
                     },
@@ -3447,7 +3447,7 @@ fn test_arch_x86_detail() {
                 b"\xd8\x81\xc6\x34",
                 &[X86Operand {
                     size: 4,
-                    access: Some(RegAccessType::ReadOnly),
+                    access: Some(AccessType::ReadOnly),
                     op_type: Mem(X86OpMem(x86_op_mem {
                         segment: 0,
                         base: X86_REG_BX,
@@ -3465,13 +3465,13 @@ fn test_arch_x86_detail() {
                 &[
                     X86Operand {
                         size: 1,
-                        access: Some(RegAccessType::ReadWrite),
+                        access: Some(AccessType::ReadWrite),
                         op_type: Reg(RegId(X86_REG_AL as RegIdInt)),
                         ..Default::default()
                     },
                     X86Operand {
                         size: 1,
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         op_type: Mem(X86OpMem(x86_op_mem {
                             segment: 0,
                             base: X86_REG_BX,
@@ -3505,13 +3505,13 @@ fn test_arch_x86_detail() {
                 &[
                     X86Operand {
                         size: 4,
-                        access: Some(RegAccessType::WriteOnly),
+                        access: Some(AccessType::WriteOnly),
                         op_type: Reg(RegId(X86_REG_ECX as RegIdInt)),
                         ..Default::default()
                     },
                     X86Operand {
                         size: 4,
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         op_type: Mem(X86OpMem(x86_op_mem {
                             segment: 0,
                             base: X86_REG_EDX,
@@ -3530,13 +3530,13 @@ fn test_arch_x86_detail() {
                 &[
                     X86Operand {
                         size: 4,
-                        access: Some(RegAccessType::ReadWrite),
+                        access: Some(AccessType::ReadWrite),
                         op_type: Reg(RegId(X86_REG_EAX as RegIdInt)),
                         ..Default::default()
                     },
                     X86Operand {
                         size: 4,
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         op_type: Reg(RegId(X86_REG_EBX as RegIdInt)),
                         ..Default::default()
                     },
@@ -3549,7 +3549,7 @@ fn test_arch_x86_detail() {
                 &[
                     X86Operand {
                         size: 4,
-                        access: Some(RegAccessType::ReadWrite),
+                        access: Some(AccessType::ReadWrite),
                         op_type: Reg(RegId(X86_REG_ESI as RegIdInt)),
                         ..Default::default()
                     },
@@ -3582,7 +3582,7 @@ fn test_arch_x86_detail() {
                 b"\x55",
                 &[X86Operand {
                     size: 8,
-                    access: Some(RegAccessType::ReadOnly),
+                    access: Some(AccessType::ReadOnly),
                     op_type: Reg(RegId(X86_REG_RBP as RegIdInt)),
                     ..Default::default()
                 }],
@@ -3594,13 +3594,13 @@ fn test_arch_x86_detail() {
                 &[
                     X86Operand {
                         size: 8,
-                        access: Some(RegAccessType::WriteOnly),
+                        access: Some(AccessType::WriteOnly),
                         op_type: Reg(RegId(X86_REG_RAX as RegIdInt)),
                         ..Default::default()
                     },
                     X86Operand {
                         size: 8,
-                        access: Some(RegAccessType::ReadOnly),
+                        access: Some(AccessType::ReadOnly),
                         op_type: Mem(X86OpMem(x86_op_mem {
                             segment: 0,
                             base: X86_REG_RIP,


### PR DESCRIPTION
AccessType is meant for operands, not registers. Rename the type and keep RegAccessType as type alias for compat. Fixes #135.