### PR TITLE
add check_only feature to disable building the C code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,8 @@ jobs:
       - name: test
         run: env ${{ matrix.rust.env }} ./capstone-rs/ci/test.sh
 
-      - name: test (all features)
-        run: env ${{ matrix.rust.env }} ALL_FEATURES=1 ./capstone-rs/ci/test.sh
+      - name: test (with bindgen)
+        run: env ${{ matrix.rust.env }} FEATURES="use_bindgen" ./capstone-rs/ci/test.sh
 
       - name: test (only enable x86 and arm64)
         run: env ${{ matrix.rust.env }} FEATURES=std,full,arch_x86,arch_arm64 NO_DEFAULT_FEATURES=1 ./capstone-rs/ci/test.sh

--- a/capstone-rs/Cargo.toml
+++ b/capstone-rs/Cargo.toml
@@ -76,3 +76,5 @@ arch_tricore = ["capstone-sys/arch_tricore"]
 arch_wasm = ["capstone-sys/arch_wasm"]
 arch_x86 = ["capstone-sys/arch_x86"]
 arch_xcore = ["capstone-sys/arch_xcore"]
+# Can be used to accelerate check builds by not building C code
+check_only = ["capstone-sys/check_only"]

--- a/capstone-sys/Cargo.toml
+++ b/capstone-sys/Cargo.toml
@@ -75,3 +75,5 @@ arch_tricore = []
 arch_wasm = []
 arch_x86 = []
 arch_xcore = []
+# Can be used to accelerate check builds by not building C code
+check_only = []

--- a/capstone-sys/build.rs
+++ b/capstone-sys/build.rs
@@ -326,6 +326,7 @@ fn main() {
     // C header search paths
     let mut header_search_paths: Vec<PathBuf> = Vec::new();
 
+    // speed up cargo check by skipping native part
     if !cfg!(feature = "check_only") {
         build_capstone_cc();
     }

--- a/capstone-sys/build.rs
+++ b/capstone-sys/build.rs
@@ -326,7 +326,9 @@ fn main() {
     // C header search paths
     let mut header_search_paths: Vec<PathBuf> = Vec::new();
 
-    build_capstone_cc();
+    if !cfg!(feature = "check_only") {
+        build_capstone_cc();
+    }
 
     header_search_paths.push([CAPSTONE_DIR, "include", "capstone"].iter().collect());
     link_type = Some(LinkType::Static);


### PR DESCRIPTION
I am looking into ways for how we can speed up check-builds in Miri (see https://github.com/rust-lang/miri/issues/4461). The libffi build script accounts for a significant fraction of the remaining build time here since the C code still gets built, even when that is entirely unnecessary for a check build.

In the rustc workspace, we have a `check_only` feature on some crates for exactly this purpose. I wonder if you'd be open to the idea of having a similar feature for libffi? Of course I would prefer to actually have native support in cargo for this but that idea has a bunch of unanswered design questions (https://github.com/rust-lang/cargo/issues/4001). So meanwhile, the best we can do is hack it in ourselves. This is done with a cargo feature to have cargo properly cache the build with and without the feature and avoid rebuilds when the flag changes. I'm happy to bikeshed the name, e.g. making it more clear that this is an unstable/unsupported configuration if you prefer that.  Could you imagine landing something like this?