### PR TITLE
Update description website in Cargo.toml

### DIFF
--- a/capstone-rs/Cargo.toml
+++ b/capstone-rs/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["m4b <m4b.github.io@gmail.com>",
            "Richo Healey <richo@psych0tik.net>",
            "Travis Finkenauer <tmfinken@gmail.com>"]
-description = "High level bindings to capstone disassembly engine (https://capstone-engine.org/)"
+description = "High level bindings to capstone disassembly engine (https://www.capstone-engine.org/)"
 keywords = ["disassemble"]
 license = "MIT"
 name = "capstone"


### PR DESCRIPTION
## Problem

When I visit the website in the description of the crate, I see an error page.

<img width="1312" height="695" alt="image" src="https://github.com/user-attachments/assets/9d770080-d9ad-4068-ba9d-95bd0ee86316" />

## Solution

Update the description website to accurately capture the www subdomain.