### PR TITLE
Replace `std::error::Error` with `core::error::Error`

### DIFF
--- a/capstone-rs/src/error.rs
+++ b/capstone-rs/src/error.rs
@@ -72,9 +72,7 @@ capstone_error_def!(
     => UnsupportedX86Masm = CS_ERR_X86_MASM;
 );
 
-// Required until https://github.com/rust-lang/rust/issues/103765 is resolved
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 pub type CsResult<T> = result::Result<T, Error>;
 


### PR DESCRIPTION
[This was stabilized in Rust 1.81](https://github.com/rust-lang/rust/pull/125951) and was pointed out [by the comment above the impl](https://github.com/capstone-rust/capstone-rs/blob/85534a97ca7b5f8cc0abe2fea4d42fded803214d/capstone-rs/src/error.rs#L75).

**This will require an MSRV bump to 1.81, which released [a year ago](https://releases.rs/docs/1.81.0), maintaining the previous MSRV gap from [when it was last bumped](https://github.com/capstone-rust/capstone-rs/commit/814558ac016ccde2ce6122ffd09756ab97b6ad4e)**.

Pending making any MSRV changes in case someone else would prefer to do it themselves, or review.