### PR TITLE
ci: upgrade cirrus CI to FreeBSD 15.0 to avoid curl issues

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-14-3
+  image_family: freebsd-15-0-amd64-zfs
 
 test_task:
   env:


### PR DESCRIPTION
Context: https://github.com/capstone-rust/capstone-rs/pull/178#issuecomment-3912186601