### PR TITLE
sys: only compile enabled arch sources in build.rs

### DIFF
--- a/capstone-sys/build.rs
+++ b/capstone-sys/build.rs
@@ -121,7 +121,7 @@ fn build_capstone_cc() {
             "x86" => cfg!(feature = "arch_x86"),
             "xcore" => cfg!(feature = "arch_xcore"),
             "xtensa" => cfg!(feature = "arch_xtensa"),
-            _ => panic!("Unhandled arch dir {dir_name}"),
+            _ => panic!("Unhandled arch dir {}", dir_name),
         }
     }
 

--- a/capstone-sys/build.rs
+++ b/capstone-sys/build.rs
@@ -96,7 +96,6 @@ fn build_capstone_cc() {
     }
 
     fn is_arch_enabled(dir_name: &str) -> bool {
-        #[allow(clippy::match_like_matches_macro)]
         match dir_name.to_lowercase().as_str() {
             "aarch64" => cfg!(feature = "arch_aarch64"),
             "alpha" => cfg!(feature = "arch_alpha"),

--- a/capstone-sys/build.rs
+++ b/capstone-sys/build.rs
@@ -96,6 +96,7 @@ fn build_capstone_cc() {
     }
 
     fn is_arch_enabled(dir_name: &str) -> bool {
+        #[allow(clippy::match_like_matches_macro)]
         match dir_name.to_lowercase().as_str() {
             "aarch64" => cfg!(feature = "arch_aarch64"),
             "alpha" => cfg!(feature = "arch_alpha"),
@@ -120,7 +121,7 @@ fn build_capstone_cc() {
             "x86" => cfg!(feature = "arch_x86"),
             "xcore" => cfg!(feature = "arch_xcore"),
             "xtensa" => cfg!(feature = "arch_xtensa"),
-            _ => false,
+            _ => panic!("Unhandled arch dir {dir_name}"),
         }
     }
 

--- a/capstone-sys/build.rs
+++ b/capstone-sys/build.rs
@@ -95,12 +95,42 @@ fn build_capstone_cc() {
         })
     }
 
+    fn is_arch_enabled(dir_name: &str) -> bool {
+        match dir_name.to_lowercase().as_str() {
+            "aarch64" => cfg!(feature = "arch_aarch64"),
+            "alpha" => cfg!(feature = "arch_alpha"),
+            "arc" => cfg!(feature = "arch_arc"),
+            "arm" => cfg!(feature = "arch_arm"),
+            "bpf" => cfg!(feature = "arch_bpf"),
+            "evm" => cfg!(feature = "arch_evm"),
+            "hppa" => cfg!(feature = "arch_hppa"),
+            "loongarch" => cfg!(feature = "arch_loongarch"),
+            "m680x" => cfg!(feature = "arch_m680x"),
+            "m68k" => cfg!(feature = "arch_m68k"),
+            "mips" => cfg!(feature = "arch_mips"),
+            "mos65xx" => cfg!(feature = "arch_mos65xx"),
+            "powerpc" => cfg!(feature = "arch_powerpc"),
+            "riscv" => cfg!(feature = "arch_riscv"),
+            "sh" => cfg!(feature = "arch_sh"),
+            "sparc" => cfg!(feature = "arch_sparc"),
+            "systemz" => cfg!(feature = "arch_systemz"),
+            "tms320c64x" => cfg!(feature = "arch_tms320c64x"),
+            "tricore" => cfg!(feature = "arch_tricore"),
+            "wasm" => cfg!(feature = "arch_wasm"),
+            "x86" => cfg!(feature = "arch_x86"),
+            "xcore" => cfg!(feature = "arch_xcore"),
+            "xtensa" => cfg!(feature = "arch_xtensa"),
+            _ => false,
+        }
+    }
+
     fn find_arch_dirs() -> Vec<String> {
         read_dir_and_filter(&format!("{}/{}", CAPSTONE_DIR, "arch"), |e| {
             let file_type = e
                 .file_type()
                 .expect("Failed to read capstone source directory");
-            file_type.is_dir()
+            let dir_name = e.file_name().into_string().expect("Invalid filename");
+            file_type.is_dir() && is_arch_enabled(&dir_name)
         })
     }
 


### PR DESCRIPTION
In GCC 14+, -Wimplicit-function-declaration became an error that -w flag cannot suppress. The auto-generated AArch64 sources in capstone v6 trigger
this error even when the AArch64 feature is disabled, because build.rs previously compiled all arch directories unconditionally.

Filter arch directories by enabled cargo features, so only selected architectures' sources are compiled.